### PR TITLE
Fixed doc-missing-type: Argument and parameter-type-not-in-doc: Argument errors

### DIFF
--- a/ansible_collections/infoblox/nios_modules/plugins/modules/nios_fixed_address.py
+++ b/ansible_collections/infoblox/nios_modules/plugins/modules/nios_fixed_address.py
@@ -35,10 +35,12 @@ options:
   ipaddr:
     description:
       - IPV4/V6 address of the fixed address.
+    type: str
     required: true
   mac:
     description:
       - The MAC address of the interface.
+    type: str
     required: true
   network:
     description:
@@ -51,6 +53,7 @@ options:
     description:
       - Configures the name of the network view to associate with this
         configured instance.
+    type: str
     required: false
     default: default
   options:
@@ -59,16 +62,20 @@ options:
         the configured network instance.  This argument accepts a list
         of values (see suboptions).  When configuring suboptions at
         least one of C(name) or C(num) must be specified.
+    type: list
     suboptions:
       name:
         description:
           - The name of the DHCP option to configure
+        type: str
       num:
         description:
           - The number of the DHCP option to configure
+        type: int
       value:
         description:
           - The value of the DHCP option specified by C(name)
+        type: str
         required: true
       use_option:
         description:
@@ -78,12 +85,14 @@ options:
       vendor_class:
         description:
           - The name of the space this DHCP option is associated to
+        type: str
         default: DHCP
   extattrs:
     description:
       - Allows for the configuration of Extensible Attributes on the
         instance of the object.  This argument accepts a set of key / value
         pairs for configuration.
+    type: dict
   comment:
     description:
       - Configures a text string comment to be associated with the instance
@@ -96,6 +105,7 @@ options:
         the NIOS server.  When this value is set to C(present), the object
         is configured on the device and when this value is set to C(absent)
         the value is removed (if necessary) from the device.
+    type: str
     default: present
     choices:
       - present


### PR DESCRIPTION
Fixed errors in file nios_host_record.py
Please review the PR @Vaishnavi-infoblox 