### PR TITLE
Fixed errors of nios_host_record

### DIFF
--- a/ansible_collections/infoblox/nios_modules/plugins/modules/nios_host_record.py
+++ b/ansible_collections/infoblox/nios_modules/plugins/modules/nios_host_record.py
@@ -181,6 +181,7 @@ EXAMPLES = '''
     ipv4:
       - address: 192.168.10.1
     aliases:
+      - cname.ansible.com
     state: present
     provider:
       host: "{{ inventory_hostname_short }}"

--- a/ansible_collections/infoblox/nios_modules/plugins/modules/nios_host_record.py
+++ b/ansible_collections/infoblox/nios_modules/plugins/modules/nios_host_record.py
@@ -31,11 +31,13 @@ options:
       - Specifies the fully qualified hostname to add or remove from
         the system. User can also update the hostname as it is possible
         to pass a dict containing I(new_name), I(old_name). See examples.
+    type: str
     required: true
   view:
     description:
       - Sets the DNS view to associate this host record with.  The DNS
         view must already be configured on the system
+    type: str
     required: true
     default: default
     aliases:
@@ -54,6 +56,7 @@ options:
     description:
       - Configures the IPv4 addresses for this host record.  This argument
         accepts a list of values (see suboptions)
+    type: list
     aliases:
       - ipv4
     suboptions:
@@ -64,6 +67,7 @@ options:
             I(nios_next_ip) and I(CIDR network range). If user wants to add or
             remove the ipv4 address from existing record, I(add/remove)
             params need to be used. See examples
+        type: str
         required: true
         aliases:
           - address
@@ -71,6 +75,7 @@ options:
         description:
           - Configure the host_record over DHCP instead of DNS, if user
             changes it to true, user need to mention MAC address to configure
+        type: bool
         required: false
         aliases:
           - dhcp
@@ -78,6 +83,7 @@ options:
         description:
           - Configures the hardware MAC address for the host record. If user makes
             DHCP to true, user need to mention MAC address.
+        type: str
         required: false
         aliases:
           - mac
@@ -105,12 +111,14 @@ options:
     description:
       - Configures the IPv6 addresses for the host record.  This argument
         accepts a list of values (see options)
+    type: list
     aliases:
       - ipv6
     suboptions:
       ipv6addr:
         description:
           - Configures the IPv6 address for the host record
+        type: str
         required: true
         aliases:
           - address
@@ -118,23 +126,35 @@ options:
         description:
           - Configure the host_record over DHCP instead of DNS, if user
             changes it to true, user need to mention MAC address to configure
+        type: bool
         required: false
         aliases:
           - dhcp
+      mac:
+        description:
+          - Configures the hardware MAC address for the host record. If user makes
+            DHCP to true, user need to mention MAC address.
+        type: str
+        required: false
+        aliases:
+          - mac
   aliases:
     version_added: "2.6"
     description:
       - Configures an optional list of additional aliases to add to the host
         record. These are equivalent to CNAMEs but held within a host
         record. Must be in list format.
+    type: list
   ttl:
     description:
       - Configures the TTL to be associated with this host record
+    type: int
   extattrs:
     description:
       - Allows for the configuration of Extensible Attributes on the
         instance of the object.  This argument accepts a set of key / value
         pairs for configuration.
+    type: dict
   comment:
     description:
       - Configures a text string comment to be associated with the instance
@@ -147,6 +167,7 @@ options:
         the NIOS server.  When this value is set to C(present), the object
         is configured on the device and when this value is set to C(absent)
         the value is removed (if necessary) from the device.
+    type: str
     default: present
     choices:
       - present
@@ -160,7 +181,6 @@ EXAMPLES = '''
     ipv4:
       - address: 192.168.10.1
     aliases:
-      - cname.ansible.com
     state: present
     provider:
       host: "{{ inventory_hostname_short }}"


### PR DESCRIPTION
Fixed  the following errors:
doc-missing-type: Argument
parameter-type-not-in-doc: Argument 
undocumented-parameter: Argument errors
@Vaishnavi-infoblox Please review the PR