### PR TITLE
Add bootfile_name (67) text as vendor specific option

### DIFF
--- a/ansible_collections/infoblox/nios_modules/plugins/modules/nios_network.py
+++ b/ansible_collections/infoblox/nios_modules/plugins/modules/nios_network.py
@@ -244,7 +244,7 @@ def check_vendor_specific_dhcp_option(module, ib_spec):
         if isinstance(module.params[key], list):
             temp_dict = module.params[key][0]
             if 'num' in temp_dict:
-                if temp_dict['num'] in (43, 124, 125):
+                if temp_dict['num'] in (43, 124, 125, 67):
                     del module.params[key][0]['use_option']
     return ib_spec
 


### PR DESCRIPTION
while running nios_network in check mode, nios_network will find a use_option parameter in the provided bootfile_name option, and no use_option on the existing bootfile_name.
Suggesting to add 67 into the check_vendor_specific_dhcp_option hack, that will allow to remove the use_option key on the bootfile_name option, providing it is the first one of the list of options.