### PR TITLE
fix to be able to remove aliases with module nios_host_record

### DIFF
--- a/ansible_collections/infoblox/nios_modules/plugins/module_utils/api.py
+++ b/ansible_collections/infoblox/nios_modules/plugins/module_utils/api.py
@@ -482,6 +482,9 @@ class WapiModule(WapiBase):
                 return False
 
             elif isinstance(proposed_item, list):
+                if key == 'aliases':
+                    if set(current_item) != set(proposed_item):
+                        return False
                 for subitem in proposed_item:
                     if not self.issubset(subitem, current_item):
                         return False


### PR DESCRIPTION
I sent [this same PR](https://github.com/ansible-collections/community.general/pull/1470/) to `community.general` collection and the maintainers asked me to also send it to this repo

This fix allows to remove aliases from host objects using module `nios_host_record`. All the details are in https://github.com/ansible-collections/community.general/issues/1335

As I am not familiar with the nios modules and `nios_modules/plugins/module_utils/api.py` is used by many other modules I tried that this PR only affects the use case I tested. That's why I use `if key == 'aliases'` . I verified that that there is no other nios module using an argument named `aliases` so I think this fix should only apply for the use case I tried to fix. Let me know if you know of a better approach to fix the bug