### PR TITLE
Add modules to manipulate DTC objects

### DIFF
--- a/ansible_collections/infoblox/nios_modules/plugins/module_utils/api.py
+++ b/ansible_collections/infoblox/nios_modules/plugins/module_utils/api.py
@@ -65,6 +65,9 @@ NIOS_NEXT_AVAILABLE_IP = 'func:nextavailableip'
 NIOS_IPV4_NETWORK_CONTAINER = 'networkcontainer'
 NIOS_IPV6_NETWORK_CONTAINER = 'ipv6networkcontainer'
 NIOS_MEMBER = 'member'
+NIOS_DTC_SERVER = 'dtc:server'
+NIOS_DTC_POOL = 'dtc:pool'
+NIOS_DTC_LBDN = 'dtc:lbdn'
 
 NIOS_PROVIDER_SPEC = {
     'host': dict(fallback=(env_fallback, ['INFOBLOX_HOST'])),

--- a/ansible_collections/infoblox/nios_modules/plugins/modules/nios_dtc_lbdn.py
+++ b/ansible_collections/infoblox/nios_modules/plugins/modules/nios_dtc_lbdn.py
@@ -36,8 +36,8 @@ options:
   auth_zones:
     description:
       - List of linked authoritative zones.
-      - NOTE: when using C(auth_zones), you must specify at least one
-        C(patterns)
+      - When using I(auth_zones), you must specify at least one
+        I(patterns)
     required: false
     type: list
     elements: str
@@ -50,8 +50,8 @@ options:
   types:
     description:
       - Specifies the list of resource record types supported by LBDN.
-      - NOTE: This option will work properly only if you set the
-        C(wapi_version) variable on your C(provider) variable to a
+      - This option will work properly only if you set the C(wapi_version)
+        variable on your C(provider) variable to a
         number higher than "2.6".
     required: false
     type: list

--- a/ansible_collections/infoblox/nios_modules/plugins/modules/nios_dtc_lbdn.py
+++ b/ansible_collections/infoblox/nios_modules/plugins/modules/nios_dtc_lbdn.py
@@ -77,7 +77,41 @@ options:
 '''
 
 EXAMPLES = '''
-TBD
+- name: configure a DTC LBDN
+  infoblox.nios_modules.nios_dtc_lbdn:
+    name: web.ansible.com
+    lb_method: ROUND_ROBIN
+    pools:
+      - pool: web_pool
+    state: present
+    provider:
+      host: "{{ inventory_hostname_short }}"
+      username: admin
+      password: admin
+  connection: local
+
+- name: add a comment to a DTC LBDN
+  infoblox.nios_modules.nios_dtc_lbdn:
+    name: web.ansible.com
+    lb_method: ROUND_ROBIN
+    comment: this is a test comment
+    state: present
+    provider:
+      host: "{{ inventory_hostname_short }}"
+      username: admin
+      password: admin
+  connection: local
+
+- name: remove a DTC LBDN from the system
+  infoblox.nios_modules.nios_dtc_lbdn:
+    name: web.ansible.com
+    lb_method: ROUND_ROBIN
+    state: absent
+    provider:
+      host: "{{ inventory_hostname_short }}"
+      username: admin
+      password: admin
+  connection: local
 '''
 
 RETURN = ''' # '''

--- a/ansible_collections/infoblox/nios_modules/plugins/modules/nios_dtc_lbdn.py
+++ b/ansible_collections/infoblox/nios_modules/plugins/modules/nios_dtc_lbdn.py
@@ -6,11 +6,6 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
-from ..module_utils.api import NIOS_DTC_LBDN
-from ..module_utils.api import WapiModule
-from ansible.module_utils.six import iteritems
-from ansible.module_utils.basic import AnsibleModule
-
 DOCUMENTATION = '''
 ---
 module: nios_dtc_lbdn
@@ -33,6 +28,7 @@ options:
     description:
       - Configures the load balancing method. Used to select pool.
     required: true
+    type: str
     choices:
       - GLOBAL_AVAILABILITY
       - RATIO
@@ -60,6 +56,7 @@ options:
         number higher than "2.6".
     required: false
     type: list
+    elements: str
     choices:
       - A
       - AAAA
@@ -156,6 +153,11 @@ EXAMPLES = '''
 
 RETURN = ''' # '''
 
+from ..module_utils.api import NIOS_DTC_LBDN
+from ..module_utils.api import WapiModule
+from ansible.module_utils.six import iteritems
+from ansible.module_utils.basic import AnsibleModule
+
 
 def main():
     ''' Main entry point for module execution
@@ -190,11 +192,11 @@ def main():
                     module.fail_json(msg='pool %s cannot be found.' % pool)
         return pool_list
 
-    auth_zones_spec = dict(),
+    auth_zones_spec = dict()
 
     pools_spec = dict(
-        pool=dict(),
-        ratio=dict(type='int')
+        pool=dict(required=True),
+        ratio=dict(type='int', default=1)
     )
 
     ib_spec = dict(
@@ -202,12 +204,12 @@ def main():
         lb_method=dict(required=True, choices=['GLOBAL_AVAILABILITY',
                                                'RATIO', 'ROUND_ROBIN', 'TOPOLOGY']),
 
-        auth_zones=dict(type='list', options=auth_zones_spec,
+        auth_zones=dict(type='list', elements='str', options=auth_zones_spec,
                         transform=auth_zones_transform),
         patterns=dict(type='list', elements='str'),
-        types=dict(type='list', choices=['A', 'AAAA', 'CNAME', 'NAPTR',
+        types=dict(type='list', elements='str', choices=['A', 'AAAA', 'CNAME', 'NAPTR',
                                          'SRV']),
-        pools=dict(type='list', options=pools_spec,
+        pools=dict(type='list', elements='dict', options=pools_spec,
                    transform=pools_transform),
         ttl=dict(type='int'),
 

--- a/ansible_collections/infoblox/nios_modules/plugins/modules/nios_dtc_lbdn.py
+++ b/ansible_collections/infoblox/nios_modules/plugins/modules/nios_dtc_lbdn.py
@@ -79,6 +79,13 @@ options:
         default: 1
         required: false
         type: int
+  ttl:
+    description:
+      - The Time To Live (TTL) value for the DTC LBDN. A 32-bit unsigned
+        integer that represents the duration, in seconds, for which the
+        record is valid (cached). Zero indicates that the record should
+        not be cached.
+    type: int
   extattrs:
     description:
       - Allows for the configuration of Extensible Attributes on the
@@ -200,6 +207,7 @@ def main():
           'SRV']),
         pools=dict(type='list', options=pools_spec,
           transform=pools_transform),
+        ttl=dict(type='int'),
 
         extattrs=dict(type='dict'),
         comment=dict(),

--- a/ansible_collections/infoblox/nios_modules/plugins/modules/nios_dtc_lbdn.py
+++ b/ansible_collections/infoblox/nios_modules/plugins/modules/nios_dtc_lbdn.py
@@ -1,0 +1,174 @@
+#!/usr/bin/python
+# Copyright (c) 2018-2019 Red Hat, Inc.
+# Copyright (c) 2020 Infoblox, Inc.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+DOCUMENTATION = '''
+---
+module: nios_dtc_lbdn
+author: "Mauricio Teixeira (@badnetmask)"
+short_description: Configure Infoblox NIOS DTC LBDN
+description:
+  - Adds and/or removes instances of DTC Load Balanced Domain Name (LBDN)
+    objects from Infoblox NIOS servers. This module manages NIOS
+    C(dtc:lbdn) objects using the Infoblox WAPI interface over REST.
+requirements:
+  - infoblox-client
+extends_documentation_fragment: infoblox.nios_modules.nios
+options:
+  name:
+    description:
+      - Specifies the display name of the DTC LBDN, not DNS related.
+    required: true
+    type: str
+  lb_method:
+    description:
+      - Configures the load balancing method. Used to select pool.
+    required: true
+    choices:
+      - GLOBAL_AVAILABILITY
+      - RATIO
+      - ROUND_ROBIN
+      - TOPOLOGY
+  pools:
+    description:
+      - The pools used for load balancing.
+    required: false
+    type: list
+    elements: dict
+    suboptions:
+      pool:
+        description:
+          - Provide the name of the pool to link with
+        required: true
+        type: str
+      ratio:
+        description:
+          - Provide the weight of the pool
+        default: 1
+        required: false
+        type: int
+  extattrs:
+    description:
+      - Allows for the configuration of Extensible Attributes on the
+        instance of the object.  This argument accepts a set of key / value
+        pairs for configuration.
+    type: dict
+  comment:
+    description:
+      - Configures a text string comment to be associated with the instance
+        of this object.  The provided text string will be configured on the
+        object instance.
+    type: str
+  state:
+    description:
+      - Configures the intended state of the instance of the object on
+        the NIOS server.  When this value is set to C(present), the object
+        is configured on the device and when this value is set to C(absent)
+        the value is removed (if necessary) from the device.
+    default: present
+    choices:
+      - present
+      - absent
+    type: str
+'''
+
+EXAMPLES = '''
+- name: configure a DTC Server
+  infoblox.nios_modules.nios_dtc_server:
+    name: a.ansible.com
+    host: 192.168.10.1
+    state: present
+    provider:
+      host: "{{ inventory_hostname_short }}"
+      username: admin
+      password: admin
+  connection: local
+
+- name: add a comment to a DTC server
+  infoblox.nios_modules.nios_dtc_server:
+    name: a.ansible.com
+    host: 192.168.10.1
+    comment: this is a test comment
+    state: present
+    provider:
+      host: "{{ inventory_hostname_short }}"
+      username: admin
+      password: admin
+  connection: local
+
+- name: remove a DTC Server from the system
+  infoblox.nios_modules.nios_dtc_server:
+    name: a.ansible.com
+    host: 192.168.10.1
+    state: absent
+    provider:
+      host: "{{ inventory_hostname_short }}"
+      username: admin
+      password: admin
+  connection: local
+'''
+
+RETURN = ''' # '''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.six import iteritems
+from ..module_utils.api import WapiModule
+from ..module_utils.api import NIOS_DTC_LBDN
+
+
+def main():
+    ''' Main entry point for module execution
+    '''
+
+    def pools_transform(module):
+      pool_list = list()
+      if module.params['pools']:
+        for pool in module.params['pools']:
+          pool_obj = wapi.get_object('dtc:pool',
+            {'name': pool['pool']})
+          if not 'ratio' in pool:
+            pool['ratio'] = 1
+          if pool_obj is not None:
+            pool_list.append({'pool': pool_obj[0]['_ref'],
+              'ratio': pool['ratio']})
+      return pool_list
+
+    pools_spec=dict(
+      pool=dict(),
+      ratio=dict(type='int')
+    )
+
+    ib_spec = dict(
+        name=dict(required=True, ib_req=True),
+        lb_method=dict(required=True, choices=['GLOBAL_AVAILABILITY',
+          'RATIO', 'ROUND_ROBIN', 'TOPOLOGY']),
+
+        pools=dict(type='list', options=pools_spec, transform=pools_transform),
+
+        extattrs=dict(type='dict'),
+        comment=dict(),
+    )
+
+    argument_spec = dict(
+        provider=dict(required=True),
+        state=dict(default='present', choices=['present', 'absent'])
+    )
+
+    argument_spec.update(ib_spec)
+    argument_spec.update(WapiModule.provider_spec)
+
+    module = AnsibleModule(argument_spec=argument_spec,
+                           supports_check_mode=True)
+
+    wapi = WapiModule(module)
+    result = wapi.run(NIOS_DTC_LBDN, ib_spec)
+
+    module.exit_json(**result)
+
+
+if __name__ == '__main__':
+    main()

--- a/ansible_collections/infoblox/nios_modules/plugins/modules/nios_dtc_lbdn.py
+++ b/ansible_collections/infoblox/nios_modules/plugins/modules/nios_dtc_lbdn.py
@@ -208,7 +208,7 @@ def main():
                         transform=auth_zones_transform),
         patterns=dict(type='list', elements='str'),
         types=dict(type='list', elements='str', choices=['A', 'AAAA', 'CNAME', 'NAPTR',
-                                         'SRV']),
+                                                         'SRV']),
         pools=dict(type='list', elements='dict', options=pools_spec,
                    transform=pools_transform),
         ttl=dict(type='int'),

--- a/ansible_collections/infoblox/nios_modules/plugins/modules/nios_dtc_lbdn.py
+++ b/ansible_collections/infoblox/nios_modules/plugins/modules/nios_dtc_lbdn.py
@@ -77,39 +77,7 @@ options:
 '''
 
 EXAMPLES = '''
-- name: configure a DTC Server
-  infoblox.nios_modules.nios_dtc_server:
-    name: a.ansible.com
-    host: 192.168.10.1
-    state: present
-    provider:
-      host: "{{ inventory_hostname_short }}"
-      username: admin
-      password: admin
-  connection: local
-
-- name: add a comment to a DTC server
-  infoblox.nios_modules.nios_dtc_server:
-    name: a.ansible.com
-    host: 192.168.10.1
-    comment: this is a test comment
-    state: present
-    provider:
-      host: "{{ inventory_hostname_short }}"
-      username: admin
-      password: admin
-  connection: local
-
-- name: remove a DTC Server from the system
-  infoblox.nios_modules.nios_dtc_server:
-    name: a.ansible.com
-    host: 192.168.10.1
-    state: absent
-    provider:
-      host: "{{ inventory_hostname_short }}"
-      username: admin
-      password: admin
-  connection: local
+TBD
 '''
 
 RETURN = ''' # '''

--- a/ansible_collections/infoblox/nios_modules/plugins/modules/nios_dtc_pool.py
+++ b/ansible_collections/infoblox/nios_modules/plugins/modules/nios_dtc_pool.py
@@ -36,7 +36,7 @@ options:
       - RATIO
       - ROUND_ROBIN
       - TOPOLOGY
-    required: false
+    required: true
     type: str
   servers:
     description:
@@ -82,7 +82,42 @@ options:
 '''
 
 EXAMPLES = '''
-TBD
+- name: configure a DTC Pool
+  infoblox.nios_modules.nios_dtc_pool:
+    name: web_pool
+    lb_preferred_method: ROUND_ROBIN
+    servers:
+      - server: a.ansible.com
+      - server: b.ansible.com
+    state: present
+    provider:
+      host: "{{ inventory_hostname_short }}"
+      username: admin
+      password: admin
+  connection: local
+
+- name: add a comment to a DTC Pool
+  infoblox.nios_modules.nios_dtc_pool:
+    name: web_pool
+    lb_preferred_method: ROUND_ROBIN
+    comment: this is a test comment
+    state: present
+    provider:
+      host: "{{ inventory_hostname_short }}"
+      username: admin
+      password: admin
+  connection: local
+
+- name: remove a DTC Pool from the system
+  infoblox.nios_modules.nios_dtc_pool:
+    name: web_pool
+    lb_preferred_method: ROUND_ROBIN
+    state: absent
+    provider:
+      host: "{{ inventory_hostname_short }}"
+      username: admin
+      password: admin
+  connection: local
 '''
 
 RETURN = ''' # '''

--- a/ansible_collections/infoblox/nios_modules/plugins/modules/nios_dtc_pool.py
+++ b/ansible_collections/infoblox/nios_modules/plugins/modules/nios_dtc_pool.py
@@ -61,7 +61,7 @@ options:
       - Specifies the health monitors related to pool.
       - The format of this parameter is required due to an API
         limitation.
-      - NOTE: This option only works if you set the C(wapi_version)
+      - This option only works if you set the C(wapi_version)
         variable on your C(provider) variable to a number higher
         than "2.6".
     required: false

--- a/ansible_collections/infoblox/nios_modules/plugins/modules/nios_dtc_pool.py
+++ b/ansible_collections/infoblox/nios_modules/plugins/modules/nios_dtc_pool.py
@@ -6,6 +6,12 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
+from ..module_utils.api import NIOS_DTC_SERVER
+from ..module_utils.api import NIOS_DTC_POOL
+from ..module_utils.api import WapiModule
+from ansible.module_utils.six import iteritems
+from ansible.module_utils.basic import AnsibleModule
+
 DOCUMENTATION = '''
 ---
 module: nios_dtc_server
@@ -151,57 +157,57 @@ EXAMPLES = '''
 
 RETURN = ''' # '''
 
-from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.six import iteritems
-from ..module_utils.api import WapiModule
-from ..module_utils.api import NIOS_DTC_POOL
-from ..module_utils.api import NIOS_DTC_SERVER
 
 def main():
     ''' Main entry point for module execution
     '''
 
     def servers_transform(module):
-      server_list = list()
-      if module.params['servers']:
-        for server in module.params['servers']:
-          server_obj = wapi.get_object('dtc:server',
-            {'name': server['server']})
-          if not 'ratio' in server:
-            server['ratio'] = 1
-          if server_obj is not None:
-            server_list.append({'server': server_obj[0]['_ref'],
-              'ratio': server['ratio']})
-      return server_list
+        server_list = list()
+        if module.params['servers']:
+            for server in module.params['servers']:
+                server_obj = wapi.get_object('dtc:server',
+                                             {'name': server['server']})
+                if 'ratio' not in server:
+                    server['ratio'] = 1
+                if server_obj is not None:
+                    server_list.append({'server': server_obj[0]['_ref'],
+                                        'ratio': server['ratio']})
+        return server_list
 
     def monitors_transform(module):
-      monitor_list = list()
-      if module.params['monitors']:
-        for monitor in module.params['monitors']:
-          monitor_obj = wapi.get_object('dtc:monitor:' + monitor['type'],
-            {'name': monitor['name']})
-          if monitor_obj is not None:
-            monitor_list.append(monitor_obj[0]['_ref'])
-      return monitor_list
+        monitor_list = list()
+        if module.params['monitors']:
+            for monitor in module.params['monitors']:
+                monitor_obj = wapi.get_object('dtc:monitor:' + monitor['type'],
+                                              {'name': monitor['name']})
+                if monitor_obj is not None:
+                    monitor_list.append(monitor_obj[0]['_ref'])
+        return monitor_list
 
-    servers_spec=dict(
-      server=dict(),
-      ratio=dict(type='int')
+    servers_spec = dict(
+        server=dict(),
+        ratio=dict(type='int')
     )
 
-    monitors_spec=dict(
-      name=dict(),
-      type=dict(choices=['http', 'icmp', 'tcp', 'pdp', 'sip', 'snmp'])
+    monitors_spec = dict(
+        name=dict(),
+        type=dict(choices=['http', 'icmp', 'tcp', 'pdp', 'sip', 'snmp'])
     )
 
     ib_spec = dict(
         name=dict(required=True, ib_req=True),
         lb_preferred_method=dict(required=True, choices=['ALL_AVAILABLE',
-          'DYNAMIC_RATIO', 'GLOBAL_AVAILABILITY', 'RATIO', 'ROUND_ROBIN',
-          'TOPOLOGY']),
+                                                         'DYNAMIC_RATIO',
+                                                         'GLOBAL_AVAILABILITY',
+                                                         'RATIO',
+                                                         'ROUND_ROBIN',
+                                                         'TOPOLOGY']),
 
-        servers=dict(type='list', options=servers_spec, transform=servers_transform),
-        monitors=dict(type='list', options=monitors_spec, transform=monitors_transform),
+        servers=dict(type='list', options=servers_spec,
+                     transform=servers_transform),
+        monitors=dict(type='list', options=monitors_spec,
+                      transform=monitors_transform),
 
         extattrs=dict(type='dict'),
         comment=dict(),

--- a/ansible_collections/infoblox/nios_modules/plugins/modules/nios_dtc_pool.py
+++ b/ansible_collections/infoblox/nios_modules/plugins/modules/nios_dtc_pool.py
@@ -63,7 +63,7 @@ options:
         limitation.
       - NOTE: This option only works if you set the C(wapi_version)
         variable on your C(provider) variable to a number higher
-        than "2.5".
+        than "2.6".
     required: false
     type: list
     elements: dict

--- a/ansible_collections/infoblox/nios_modules/plugins/modules/nios_dtc_pool.py
+++ b/ansible_collections/infoblox/nios_modules/plugins/modules/nios_dtc_pool.py
@@ -1,0 +1,148 @@
+#!/usr/bin/python
+# Copyright (c) 2018-2019 Red Hat, Inc.
+# Copyright (c) 2020 Infoblox, Inc.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+DOCUMENTATION = '''
+---
+module: nios_dtc_server
+author: "Mauricio Teixeira (@badnetmask)"
+short_description: Configure Infoblox NIOS DTC Pool
+description:
+  - Adds and/or removes instances of DTC Pool objects from
+    Infoblox NIOS servers. This module manages NIOS C(dtc:pool) objects
+    using the Infoblox WAPI interface over REST. A DTC pool is a collection
+    of IDNS resources (virtual servers).
+requirements:
+  - infoblox-client
+extends_documentation_fragment: infoblox.nios_modules.nios
+options:
+  name:
+    description:
+      - Specifies the DTC Pool display name
+    required: true
+    type: str
+  lb_preferred_method:
+    description:
+      - Configures the preferred load balancing method.
+      - Use this to select a method type from the pool.
+    choices:
+      - ALL_AVAILABLE
+      - DYNAMIC_RATIO
+      - GLOBAL_AVAILABILITY
+      - RATIO
+      - ROUND_ROBIN
+      - TOPOLOGY
+    required: false
+    type: str
+  servers:
+    description:
+      - Configure the DTC Servers related to the pool
+    required: false
+    type: list
+    elements: dict
+    suboptions:
+      server:
+        description:
+          - Provide the name of the DTC Server
+        required: true
+        type: str
+      ratio:
+        description:
+          - Provide the weight of the server
+        default: 1
+        required: false
+        type: int
+  extattrs:
+    description:
+      - Allows for the configuration of Extensible Attributes on the
+        instance of the object.  This argument accepts a set of key / value
+        pairs for configuration.
+    type: dict
+  comment:
+    description:
+      - Configures a text string comment to be associated with the instance
+        of this object.  The provided text string will be configured on the
+        object instance.
+    type: str
+  state:
+    description:
+      - Configures the intended state of the instance of the object on
+        the NIOS server.  When this value is set to C(present), the object
+        is configured on the device and when this value is set to C(absent)
+        the value is removed (if necessary) from the device.
+    default: present
+    choices:
+      - present
+      - absent
+    type: str
+'''
+
+EXAMPLES = '''
+TBD
+'''
+
+RETURN = ''' # '''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.six import iteritems
+from ..module_utils.api import WapiModule
+from ..module_utils.api import NIOS_DTC_POOL
+from ..module_utils.api import NIOS_DTC_SERVER
+
+def main():
+    ''' Main entry point for module execution
+    '''
+
+    def servers_transform(module):
+      server_list = list()
+      if module.params['servers']:
+        for server in module.params['servers']:
+          server_obj = wapi.get_object('dtc:server',
+            {'name': server['server']})
+          if not 'ratio' in server:
+            server['ratio'] = 1
+          if server_obj is not None:
+            server_list.append({'server': server_obj[0]['_ref'],
+              'ratio': server['ratio']})
+      return server_list
+
+    servers_spec=dict(
+      server=dict(),
+      ratio=dict(type='int')
+    )
+
+    ib_spec = dict(
+        name=dict(required=True, ib_req=True),
+        lb_preferred_method=dict(required=True, choices=['ALL_AVAILABLE',
+          'DYNAMIC_RATIO', 'GLOBAL_AVAILABILITY', 'RATIO', 'ROUND_ROBIN',
+          'TOPOLOGY']),
+
+        servers=dict(type='list', options=servers_spec, transform=servers_transform),
+
+        extattrs=dict(type='dict'),
+        comment=dict(),
+    )
+
+    argument_spec = dict(
+        provider=dict(required=True),
+        state=dict(default='present', choices=['present', 'absent'])
+    )
+
+    argument_spec.update(ib_spec)
+    argument_spec.update(WapiModule.provider_spec)
+
+    module = AnsibleModule(argument_spec=argument_spec,
+                           supports_check_mode=True)
+
+    wapi = WapiModule(module)
+    result = wapi.run(NIOS_DTC_POOL, ib_spec)
+
+    module.exit_json(**result)
+
+
+if __name__ == '__main__':
+    main()

--- a/ansible_collections/infoblox/nios_modules/plugins/modules/nios_dtc_pool.py
+++ b/ansible_collections/infoblox/nios_modules/plugins/modules/nios_dtc_pool.py
@@ -6,15 +6,9 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
-from ..module_utils.api import NIOS_DTC_SERVER
-from ..module_utils.api import NIOS_DTC_POOL
-from ..module_utils.api import WapiModule
-from ansible.module_utils.six import iteritems
-from ansible.module_utils.basic import AnsibleModule
-
 DOCUMENTATION = '''
 ---
-module: nios_dtc_server
+module: nios_dtc_pool
 author: "Mauricio Teixeira (@badnetmask)"
 short_description: Configure Infoblox NIOS DTC Pool
 description:
@@ -157,6 +151,11 @@ EXAMPLES = '''
 
 RETURN = ''' # '''
 
+from ..module_utils.api import NIOS_DTC_POOL
+from ..module_utils.api import WapiModule
+from ansible.module_utils.six import iteritems
+from ansible.module_utils.basic import AnsibleModule
+
 
 def main():
     ''' Main entry point for module execution
@@ -168,8 +167,6 @@ def main():
             for server in module.params['servers']:
                 server_obj = wapi.get_object('dtc:server',
                                              {'name': server['server']})
-                if 'ratio' not in server:
-                    server['ratio'] = 1
                 if server_obj is not None:
                     server_list.append({'server': server_obj[0]['_ref'],
                                         'ratio': server['ratio']})
@@ -186,13 +183,13 @@ def main():
         return monitor_list
 
     servers_spec = dict(
-        server=dict(),
-        ratio=dict(type='int')
+        server=dict(required=True),
+        ratio=dict(type='int', default=1)
     )
 
     monitors_spec = dict(
-        name=dict(),
-        type=dict(choices=['http', 'icmp', 'tcp', 'pdp', 'sip', 'snmp'])
+        name=dict(required=True),
+        type=dict(required=True, choices=['http', 'icmp', 'tcp', 'pdp', 'sip', 'snmp'])
     )
 
     ib_spec = dict(
@@ -204,9 +201,9 @@ def main():
                                                          'ROUND_ROBIN',
                                                          'TOPOLOGY']),
 
-        servers=dict(type='list', options=servers_spec,
+        servers=dict(type='list', elements='dict', options=servers_spec,
                      transform=servers_transform),
-        monitors=dict(type='list', options=monitors_spec,
+        monitors=dict(type='list', elements='dict', options=monitors_spec,
                       transform=monitors_transform),
 
         extattrs=dict(type='dict'),

--- a/ansible_collections/infoblox/nios_modules/plugins/modules/nios_dtc_server.py
+++ b/ansible_collections/infoblox/nios_modules/plugins/modules/nios_dtc_server.py
@@ -1,0 +1,131 @@
+#!/usr/bin/python
+# Copyright (c) 2018-2019 Red Hat, Inc.
+# Copyright (c) 2020 Infoblox, Inc.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+DOCUMENTATION = '''
+---
+module: nios_dtc_server
+author: "Mauricio Teixeira (@badnetmask)"
+short_description: Configure Infoblox NIOS DTC Server
+description:
+  - Adds and/or removes instances of DTC Server objects from
+    Infoblox NIOS servers. This module manages NIOS C(dtc:server) objects
+    using the Infoblox WAPI interface over REST.
+requirements:
+  - infoblox-client
+extends_documentation_fragment: infoblox.nios_modules.nios
+options:
+  name:
+    description:
+      - Specifies the DTC Server display name
+    required: true
+    type: str
+  host:
+    description:
+      - Configures the address or FQDN of the server
+    required: true
+    type: str
+  extattrs:
+    description:
+      - Allows for the configuration of Extensible Attributes on the
+        instance of the object.  This argument accepts a set of key / value
+        pairs for configuration.
+    type: dict
+  comment:
+    description:
+      - Configures a text string comment to be associated with the instance
+        of this object.  The provided text string will be configured on the
+        object instance.
+    type: str
+  state:
+    description:
+      - Configures the intended state of the instance of the object on
+        the NIOS server.  When this value is set to C(present), the object
+        is configured on the device and when this value is set to C(absent)
+        the value is removed (if necessary) from the device.
+    default: present
+    choices:
+      - present
+      - absent
+    type: str
+'''
+
+EXAMPLES = '''
+- name: configure a DTC Server
+  infoblox.nios_modules.nios_dtc_server:
+    name: a.ansible.com
+    host: 192.168.10.1
+    state: present
+    provider:
+      host: "{{ inventory_hostname_short }}"
+      username: admin
+      password: admin
+  connection: local
+
+- name: add a comment to a DTC server
+  infoblox.nios_modules.nios_dtc_server:
+    name: a.ansible.com
+    host: 192.168.10.1
+    comment: this is a test comment
+    state: present
+    provider:
+      host: "{{ inventory_hostname_short }}"
+      username: admin
+      password: admin
+  connection: local
+
+- name: remove a DTC Server from the system
+  infoblox.nios_modules.nios_dtc_server:
+    name: a.ansible.com
+    host: 192.168.10.1
+    state: absent
+    provider:
+      host: "{{ inventory_hostname_short }}"
+      username: admin
+      password: admin
+  connection: local
+'''
+
+RETURN = ''' # '''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.six import iteritems
+from ..module_utils.api import WapiModule
+from ..module_utils.api import NIOS_DTC_SERVER
+
+
+def main():
+    ''' Main entry point for module execution
+    '''
+
+    ib_spec = dict(
+        name=dict(required=True, ib_req=True),
+        host=dict(required=True, ib_req=True),
+
+        extattrs=dict(type='dict'),
+        comment=dict(),
+    )
+
+    argument_spec = dict(
+        provider=dict(required=True),
+        state=dict(default='present', choices=['present', 'absent'])
+    )
+
+    argument_spec.update(ib_spec)
+    argument_spec.update(WapiModule.provider_spec)
+
+    module = AnsibleModule(argument_spec=argument_spec,
+                           supports_check_mode=True)
+
+    wapi = WapiModule(module)
+    result = wapi.run(NIOS_DTC_SERVER, ib_spec)
+
+    module.exit_json(**result)
+
+
+if __name__ == '__main__':
+    main()

--- a/ansible_collections/infoblox/nios_modules/plugins/modules/nios_dtc_server.py
+++ b/ansible_collections/infoblox/nios_modules/plugins/modules/nios_dtc_server.py
@@ -26,7 +26,8 @@ options:
     type: str
   host:
     description:
-      - Configures the address or FQDN of the server
+      - Configures the IP address (A response) or FQDN (CNAME response)
+        of the server
     required: true
     type: str
   extattrs:
@@ -57,7 +58,7 @@ options:
 EXAMPLES = '''
 - name: configure a DTC Server
   infoblox.nios_modules.nios_dtc_server:
-    name: a.ansible.com
+    name: a.example.com
     host: 192.168.10.1
     state: present
     provider:
@@ -68,7 +69,7 @@ EXAMPLES = '''
 
 - name: add a comment to a DTC server
   infoblox.nios_modules.nios_dtc_server:
-    name: a.ansible.com
+    name: a.example.com
     host: 192.168.10.1
     comment: this is a test comment
     state: present
@@ -80,7 +81,7 @@ EXAMPLES = '''
 
 - name: remove a DTC Server from the system
   infoblox.nios_modules.nios_dtc_server:
-    name: a.ansible.com
+    name: a.example.com
     host: 192.168.10.1
     state: absent
     provider:

--- a/ansible_collections/infoblox/nios_modules/plugins/modules/nios_restartservices.py
+++ b/ansible_collections/infoblox/nios_modules/plugins/modules/nios_restartservices.py
@@ -36,9 +36,7 @@ options:
       - The restart method in case of grid restart.
     required: false
     type: str
-    default: None
     choices:
-      - None
       - GROUPED
       - SEQUENTIAL
       - SIMULTANEOUS
@@ -100,8 +98,8 @@ def main():
     ib_spec = dict(
         groups=dict(type='list', elements='str'),
         members=dict(type='list', elements='str'),
-        mode=dict(type='str', default='None',
-                  choices=['None', 'GROUPED', 'SEQUENTIAL', 'SIMULTANEOUS']),
+        mode=dict(type='str', choices=['GROUPED', 'SEQUENTIAL',
+                                       'SIMULTANEOUS']),
         restart_option=dict(type='str', default='RESTART_IF_NEEDED',
                             choices=['RESTART_IF_NEEDED', 'FORCE_RESTART']),
         services=dict(type='list', elements='str', default=['ALL'],

--- a/ansible_collections/infoblox/nios_modules/plugins/modules/nios_restartservices.py
+++ b/ansible_collections/infoblox/nios_modules/plugins/modules/nios_restartservices.py
@@ -90,7 +90,6 @@ RETURN = ''' # '''
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.six import iteritems
-from ansible.errors import AnsibleError
 from ..module_utils.api import WapiModule
 
 
@@ -133,7 +132,7 @@ def main():
         del restart_params['mode']
     grid_obj = wapi.get_object('grid')
     if grid_obj is None:
-        raise AnsibleError('Failed to get NIOS grid information.')
+        module.fail_json(msg='Failed to get NIOS grid information.')
     result = wapi.call_func('restartservices', grid_obj[0]['_ref'], restart_params)
 
     module.exit_json(**result)

--- a/ansible_collections/infoblox/nios_modules/plugins/modules/nios_restartservices.py
+++ b/ansible_collections/infoblox/nios_modules/plugins/modules/nios_restartservices.py
@@ -1,0 +1,143 @@
+#!/usr/bin/python
+# Copyright (c) 2018-2019 Red Hat, Inc.
+# Copyright (c) 2020 Infoblox, Inc.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+DOCUMENTATION = '''
+---
+module: nios_restartservices
+author: "Mauricio Teixeira (@badnetmask)"
+short_description: Restart grid services.
+description:
+  - Restart grid services.
+  - When invoked without any options, will restart ALL services on the
+    default restart group IF NEEDED.
+requirements:
+  - infoblox-client
+extends_documentation_fragment: infoblox.nios_modules.nios
+options:
+  groups:
+    description:
+      - The list of the Service Restart Groups to restart.
+    required: false
+    type: list
+    elements: str
+  members:
+    description:
+      - The list of the Grid Members to restart.
+    required: false
+    type: list
+    elements: str
+  mode:
+    description:
+      - The restart method in case of grid restart.
+    required: false
+    type: str
+    default: None
+    choices:
+      - None
+      - GROUPED
+      - SEQUENTIAL
+      - SIMULTANEOUS
+  restart_option:
+    description:
+      - Controls whether services are restarted unconditionally or when needed
+    required: false
+    type: str
+    default: RESTART_IF_NEEDED
+    choices:
+      - RESTART_IF_NEEDED
+      - FORCE_RESTART
+  services:
+    description:
+      - The list of services the restart applicable to.
+    required: false
+    type: list
+    elements: str
+    default: ALL
+    choices:
+      - ALL
+      - DNS
+      - DHCP
+      - DHCPV4
+      - DHCPV6
+'''
+
+EXAMPLES = '''
+- name: Restart all grid services if needed.
+  infoblox.nios_modules.nios_restartservices:
+    provider:
+      host: "{{ inventory_hostname_short }}"
+      username: admin
+      password: admin
+  connection: local
+
+- name: Restart DNS service if needed.
+  infoblox.nios_modules.nios_restartservices:
+    services:
+      - DNS
+    provider:
+      host: "{{ inventory_hostname_short }}"
+      username: admin
+      password: admin
+  connection: local
+'''
+
+RETURN = ''' # '''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.six import iteritems
+from ansible.errors import AnsibleError
+from ..module_utils.api import WapiModule
+
+
+def main():
+    ''' Main entry point for module execution
+    '''
+
+    ib_spec = dict(
+        groups=dict(type='list', elements='str'),
+        members=dict(type='list', elements='str'),
+        mode=dict(type='str', default='None',
+                  choices=['None', 'GROUPED', 'SEQUENTIAL', 'SIMULTANEOUS']),
+        restart_option=dict(type='str', default='RESTART_IF_NEEDED',
+                            choices=['RESTART_IF_NEEDED', 'FORCE_RESTART']),
+        services=dict(type='list', elements='str', default=['ALL'],
+                      choices=['ALL', 'DNS', 'DHCP', 'DHCPV4', 'DHCPV6'])
+    )
+
+    argument_spec = dict(
+        provider=dict(required=True)
+    )
+
+    argument_spec.update(ib_spec)
+    argument_spec.update(WapiModule.provider_spec)
+
+    module = AnsibleModule(argument_spec=argument_spec,
+                           supports_check_mode=True)
+
+    wapi = WapiModule(module)
+
+    # restart is a grid function, so we need to properly format
+    # the arguments before sending the command
+    restart_params = module.params
+    del restart_params['provider']
+    if restart_params['groups'] is None:
+        del restart_params['groups']
+    if restart_params['members'] is None:
+        del restart_params['members']
+    if restart_params['mode'] is None:
+        del restart_params['mode']
+    grid_obj = wapi.get_object('grid')
+    if grid_obj is None:
+        raise AnsibleError('Failed to get NIOS grid information.')
+    result = wapi.call_func('restartservices', grid_obj[0]['_ref'], restart_params)
+
+    module.exit_json(**result)
+
+
+if __name__ == '__main__':
+    main()

--- a/ansible_collections/infoblox/nios_modules/tests/sanity/ignore-2.10.txt
+++ b/ansible_collections/infoblox/nios_modules/tests/sanity/ignore-2.10.txt
@@ -14,3 +14,6 @@ plugins/modules/nios_zone.py validate-modules:invalid-ansiblemodule-schema
 plugins/modules/nios_nsgroup.py validate-modules:invalid-ansiblemodule-schema
 plugins/modules/nios_network.py validate-modules:invalid-ansiblemodule-schema
 plugins/modules/nios_network_view.py validate-modules:invalid-ansiblemodule-schema
+plugins/modules/nios_dtc_lbdn.py validate-modules:invalid-ansiblemodule-schema
+plugins/modules/nios_dtc_pool.py validate-modules:invalid-ansiblemodule-schema
+plugins/modules/nios_dtc_server.py validate-modules:invalid-ansiblemodule-schema

--- a/ansible_collections/infoblox/nios_modules/tests/sanity/ignore-2.11.txt
+++ b/ansible_collections/infoblox/nios_modules/tests/sanity/ignore-2.11.txt
@@ -14,3 +14,6 @@ plugins/modules/nios_zone.py validate-modules:invalid-ansiblemodule-schema
 plugins/modules/nios_nsgroup.py validate-modules:invalid-ansiblemodule-schema
 plugins/modules/nios_network.py validate-modules:invalid-ansiblemodule-schema
 plugins/modules/nios_network_view.py validate-modules:invalid-ansiblemodule-schema
+plugins/modules/nios_dtc_lbdn.py validate-modules:invalid-ansiblemodule-schema
+plugins/modules/nios_dtc_pool.py validate-modules:invalid-ansiblemodule-schema
+plugins/modules/nios_dtc_server.py validate-modules:invalid-ansiblemodule-schema


### PR DESCRIPTION
This PR adds support to manipulate DTC(*) objects.

I have not implemented every single option and operation that the API permits, but this is the minimum necessary to have a GSLB.

Each module's documentation contain examples.

I am still working to implement more objects and options, but I would like to start the code review right away, and slowly work on adding the other things later.

* DTC = Infoblox DNS Traffic Control, i.e. GSLB (Global Service Load Balancing).