### PR TITLE
adding support for ipv6

### DIFF
--- a/ansible_collections/infoblox/nios_modules/plugins/lookup/nios_next_ip.py
+++ b/ansible_collections/infoblox/nios_modules/plugins/lookup/nios_next_ip.py
@@ -44,9 +44,9 @@ EXAMPLES = """
     ipaddr: "{{ lookup('nios_next_ip', '192.168.10.0/24', num=3, exclude=['192.168.10.1', '192.168.10.2'],
                 provider={'host': 'nios01', 'username': 'admin', 'password': 'password'}) }}"
 
-- name: return next available IP address for network 2230:52:2:1211::/64
+- name: return next available IP address for network fd30:f52:2:12::/64
   set_fact:
-    ipaddr: "{{ lookup('nios_next_ip', '2230:52:2:1211::/64', provider={'host': 'nios01', 'username': 'admin', 'password': 'password'}) }}"
+    ipaddr: "{{ lookup('nios_next_ip', 'fd30:f52:2:12::/64', provider={'host': 'nios01', 'username': 'admin', 'password': 'password'}) }}"
 """
 
 RETURN = """

--- a/ansible_collections/infoblox/nios_modules/plugins/lookup/nios_next_ip.py
+++ b/ansible_collections/infoblox/nios_modules/plugins/lookup/nios_next_ip.py
@@ -43,6 +43,10 @@ EXAMPLES = """
   set_fact:
     ipaddr: "{{ lookup('nios_next_ip', '192.168.10.0/24', num=3, exclude=['192.168.10.1', '192.168.10.2'],
                 provider={'host': 'nios01', 'username': 'admin', 'password': 'password'}) }}"
+
+- name: return next available IP address for network 2230:52:2:1211::/64
+  set_fact:
+    ipaddr: "{{ lookup('nios_next_ip', '2230:52:2:1211::/64', provider={'host': 'nios01', 'username': 'admin', 'password': 'password'}) }}"
 """
 
 RETURN = """
@@ -58,7 +62,7 @@ from ansible.plugins.lookup import LookupBase
 from ansible.module_utils._text import to_text
 from ansible.errors import AnsibleError
 from ..module_utils.api import WapiLookup
-
+import ipaddress
 
 class LookupModule(LookupBase):
 
@@ -71,7 +75,11 @@ class LookupModule(LookupBase):
         provider = kwargs.pop('provider', {})
         wapi = WapiLookup(provider)
 
-        network_obj = wapi.get_object('network', {'network': network})
+        if type(ipaddress.ip_network(network)) == ipaddress.IPv6Network:
+            network_obj = wapi.get_object('ipv6network', {'network': network})
+        else:
+            network_obj = wapi.get_object('network', {'network': network})
+
         if network_obj is None:
             raise AnsibleError('unable to find network object %s' % network)
 

--- a/ansible_collections/infoblox/nios_modules/plugins/lookup/nios_next_ip.py
+++ b/ansible_collections/infoblox/nios_modules/plugins/lookup/nios_next_ip.py
@@ -64,6 +64,7 @@ from ansible.errors import AnsibleError
 from ..module_utils.api import WapiLookup
 import ipaddress
 
+
 class LookupModule(LookupBase):
 
     def run(self, terms, variables=None, **kwargs):


### PR DESCRIPTION
SUMMARY

Current module only works with ipv4. I am adding patch to support ipv6 as well.
ISSUE TYPE

    Feature Pull Request

COMPONENT NAME

nios_next_ip
ADDITIONAL INFORMATION

Before my changes:
PLAY [localhost] ***************************************************************************************************************************************************************************************************

TASK [Find next available IP in Infoblox when host does not exist and IP is not defined] ***************************************************************************************************************************
No handlers could be found for logger "infoblox_client.connector"
fatal: [localhost]: FAILED! => {"msg": "An unhandled exception occurred while running the lookup plugin 'nios_next_ip'. Error was a <class 'ansible.errors.AnsibleError'>, original message: unable to find network object fd30:f52:2:12::/64"}

PLAY RECAP *********************************************************************************************************************************************************************************************************
localhost : ok=0 changed=0 unreachable=0 failed=1 skipped=0 rescued=0 ignored=0

After my changes:
TASK [Find next available IP in Infoblox when host does not exist and IP is not defined] ***************************************************************************************************************************
ok: [localhost]

TASK [debug] *******************************************************************************************************************************************************************************************************
ok: [localhost] => {
"msg": "fd30:f52:2:12::1"
}