### PR TITLE
Expanding for disable value

### DIFF
--- a/plugins/modules/nios_dtc_server.py
+++ b/plugins/modules/nios_dtc_server.py
@@ -35,7 +35,7 @@ options:
     type: str
   disable:
     description:
-      - Determines whether the DTC Server is disabled or not. 
+      - Determines whether the DTC Server is disabled or not.
         When this is set to False, the fixed address is enabled.
     required: false
     type: bool

--- a/plugins/modules/nios_dtc_server.py
+++ b/plugins/modules/nios_dtc_server.py
@@ -33,6 +33,13 @@ options:
         of the server
     required: true
     type: str
+  disable:
+    description:
+      - Determines whether the DTC Server is disabled or not. 
+        When this is set to False, the fixed address is enabled.
+    required: false
+    type: bool
+    default: False
   extattrs:
     description:
       - Allows for the configuration of Extensible Attributes on the
@@ -111,6 +118,7 @@ def main():
         name=dict(required=True, ib_req=True),
         host=dict(required=True, ib_req=True),
 
+        disable=dict(type='bool', default=False),
         extattrs=dict(type='dict'),
         comment=dict(),
     )


### PR DESCRIPTION
As per https://ipam.illinois.edu/wapidoc/objects/dtc.server.html API supports disable option. This patch is just exposing it to ansible.