### PR TITLE
Add support for member assignment to nios_network

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -91,7 +91,7 @@ jobs:
 
       - name: Generate coverage report
         run: |
-          if [ "${{ matrix.ansible-version }}" == "devel" ]; then pip install coverage==6.4.4; fi
+          if [ "${{ matrix.ansible-version }}" == "devel" ]; then pip install coverage==6.5.0; fi
           ansible-test coverage xml -v --group-by command --group-by version
         working-directory: /home/runner/.ansible/collections/ansible_collections/infoblox/nios_modules/
 

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -91,7 +91,7 @@ jobs:
 
       - name: Generate coverage report
         run: |
-          if [ "${{ matrix.ansible-version }}" == "devel" ]; then pip install coverage==6.4.3; fi
+          if [ "${{ matrix.ansible-version }}" == "devel" ]; then pip install coverage==6.4.4; fi
           ansible-test coverage xml -v --group-by command --group-by version
         working-directory: /home/runner/.ansible/collections/ansible_collections/infoblox/nios_modules/
 

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ __pycache__/
 # Distribution / packaging
 .Python
 env/
+.direnv/
 build/
 develop-eggs/
 dist/
@@ -99,3 +100,4 @@ ENV/
 
 # mypy
 .mypy_cache/
+infoblox-ansible.code-workspace

--- a/plugins/module_utils/api.py
+++ b/plugins/module_utils/api.py
@@ -181,6 +181,26 @@ def member_normalize(member_spec):
     return member_spec
 
 
+def convert_members_to_struct(member_spec):
+    ''' Transforms the members list of the Network module arguments into a 
+    valid WAPI struct. This function will change arguments into the valid 
+    wapi structure of the format:
+        {
+            network: 10.1.1.0/24 
+            members:
+                [
+                    {'_struct': 'dhcpmember', 'name': 'member_name1'},
+                    {'_struct': 'dhcpmember', 'name': 'member_name2'}
+                    {'_struct': 'dhcpmember', 'name': '...'}
+                ]
+        }
+    
+    '''
+    if 'members' in member_spec.keys(): 
+        member_spec['members'] = [{'_struct': 'dhcpmember', 'name': k['name']} for k in member_spec['members']]
+    return member_spec 
+
+
 def normalize_ib_spec(ib_spec):
     result = {}
     for arg in ib_spec:
@@ -314,6 +334,9 @@ class WapiModule(WapiBase):
         # checks if the object type is member to normalize the attributes being passed
         if (ib_obj_type == NIOS_MEMBER):
             proposed_object = member_normalize(proposed_object)
+
+        if (ib_obj_type == NIOS_IPV4_NETWORK or ib_obj_type == NIOS_IPV6_NETWORK):
+            proposed_object = convert_members_to_struct(proposed_object)
 
         # checks if the 'text' field has to be updated for the TXT Record
         if (ib_obj_type == NIOS_TXT_RECORD):

--- a/plugins/module_utils/api.py
+++ b/plugins/module_utils/api.py
@@ -195,9 +195,9 @@ def convert_members_to_struct(member_spec):
                 ]
         }
     '''
-    if 'members' in member_spec.keys(): 
+    if 'members' in member_spec.keys():
         member_spec['members'] = [{'_struct': 'dhcpmember', 'name': k['name']} for k in member_spec['members']]
-    return member_spec 
+    return member_spec
 
 
 def normalize_ib_spec(ib_spec):

--- a/plugins/module_utils/api.py
+++ b/plugins/module_utils/api.py
@@ -182,11 +182,11 @@ def member_normalize(member_spec):
 
 
 def convert_members_to_struct(member_spec):
-    ''' Transforms the members list of the Network module arguments into a 
-    valid WAPI struct. This function will change arguments into the valid 
+    ''' Transforms the members list of the Network module arguments into a
+    valid WAPI struct. This function will change arguments into the valid
     wapi structure of the format:
         {
-            network: 10.1.1.0/24 
+            network: 10.1.1.0/24
             members:
                 [
                     {'_struct': 'dhcpmember', 'name': 'member_name1'},
@@ -194,7 +194,6 @@ def convert_members_to_struct(member_spec):
                     {'_struct': 'dhcpmember', 'name': '...'}
                 ]
         }
-    
     '''
     if 'members' in member_spec.keys(): 
         member_spec['members'] = [{'_struct': 'dhcpmember', 'name': k['name']} for k in member_spec['members']]

--- a/plugins/modules/nios_network.py
+++ b/plugins/modules/nios_network.py
@@ -95,6 +95,17 @@ options:
       - If set to true it'll create the network container to be added or removed
         from the system.
     type: bool
+  members:
+    description:
+      - Configures the Nios Menber assignment for the configured network instance.  
+        This argument accepts a list of member names (see suboptions).
+    type: list
+    elements: dict
+    suboptions:
+      name:
+        description:
+          - The name of the Nios member to be assigned to this network.
+        type: str
   state:
     description:
       - Configures the intended state of the instance of the object on
@@ -124,6 +135,20 @@ EXAMPLES = '''
   infoblox.nios_modules.nios_network:
     network: fe80::/64
     comment: this is a test comment
+    state: present
+    provider:
+      host: "{{ inventory_hostname_short }}"
+      username: admin
+      password: admin
+  connection: local
+
+- name: Create network with member assignment for a network ipv4
+  infoblox.nios_modules.nios_network:
+    network: 192.168.10.0/24
+    comment: this is a test comment
+    members:
+      - name: member1.infoblox
+      - name: member2.infoblox
     state: present
     provider:
       host: "{{ inventory_hostname_short }}"
@@ -289,7 +314,8 @@ def main():
         template=dict(type='str'),
         extattrs=dict(type='dict'),
         comment=dict(),
-        container=dict(type='bool', ib_req=True)
+        container=dict(type='bool', ib_req=True),
+        members=dict(type='list', elements='dict')
     )
 
     argument_spec = dict(

--- a/plugins/modules/nios_network.py
+++ b/plugins/modules/nios_network.py
@@ -145,7 +145,7 @@ EXAMPLES = '''
 - name: Create network with member assignment for a network ipv4
   infoblox.nios_modules.nios_network:
     network: 192.168.10.0/24
-    comment: this is a test comment
+    comment: This is a test comment
     members:
       - name: member1.infoblox
       - name: member2.infoblox

--- a/plugins/modules/nios_network.py
+++ b/plugins/modules/nios_network.py
@@ -97,7 +97,7 @@ options:
     type: bool
   members:
     description:
-      - Configures the Nios Menber assignment for the configured network instance.  
+      - Configures the Nios Menber assignment for the configured network instance.
         This argument accepts a list of member names (see suboptions).
     type: list
     elements: dict


### PR DESCRIPTION
This PR aims to provide the support for member assignment during the creation of a network with the niso_network module. 

To support this change  'convert_members_to_struct(member_spec)' has been added to 'module_utils/api.py' that transforms the ansible input into the correct data structure required for the API endpoint. With this transformation the existing process can now successfully create the member assignment and update the assignment if needed. 

- Doco in nios_network.py updated with the definition of the members option
- Example in nios_network.py has been updated with a new example

This will address feature request:
- https://github.com/infobloxopen/infoblox-ansible/issues/69 
