### PR TITLE
feat: Add nios  network range support

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -91,7 +91,7 @@ jobs:
 
       - name: Generate coverage report
         run: |
-          if [ "${{ matrix.ansible-version }}" == "devel" ]; then pip install coverage==6.4.4; fi
+          if [ "${{ matrix.ansible-version }}" == "devel" ]; then pip install coverage==6.5.0; fi
           ansible-test coverage xml -v --group-by command --group-by version
         working-directory: /home/runner/.ansible/collections/ansible_collections/infoblox/nios_modules/
 

--- a/.gitignore
+++ b/.gitignore
@@ -101,3 +101,6 @@ ENV/
 # mypy
 .mypy_cache/
 infoblox-ansible.code-workspace
+
+# Ansible sanity test ouput
+**/ansible-test-sanity-*.json

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ __pycache__/
 # Distribution / packaging
 .Python
 env/
+.direnv/
 build/
 develop-eggs/
 dist/
@@ -99,3 +100,4 @@ ENV/
 
 # mypy
 .mypy_cache/
+infoblox-ansible.code-workspace

--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ Modules
 
 -   `nios_ptr_record` – Configure Infoblox NIOS PTR records
 
+-   `nios_range` - Configure Infoblox NIOS Network Range object
+
 -   `nios_restartservices` - Controlled restart of Infoblox NIOS services
 
 -   `nios_srv_record` – Configure Infoblox NIOS SRV records

--- a/plugins/module_utils/api.py
+++ b/plugins/module_utils/api.py
@@ -32,12 +32,12 @@ __metaclass__ = type
 import json
 import os
 from functools import partial
-from ..ansible.module_utils._text import to_native
-from ..ansible.module_utils.six import iteritems
-from ..ansible.module_utils._text import to_text
-from ..ansible.module_utils.basic import env_fallback
-from ..ansible.module_utils.common.validation import check_type_dict, safe_eval
-from ..ansible.module_utils.six import string_types
+from ansible.module_utils._text import to_native
+from ansible.module_utils.six import iteritems
+from ansible.module_utils._text import to_text
+from ansible.module_utils.basic import env_fallback
+from ansible.module_utils.common.validation import check_type_dict, safe_eval
+from ansible.module_utils.six import string_types
 
 try:
     from infoblox_client.connector import Connector

--- a/plugins/module_utils/api.py
+++ b/plugins/module_utils/api.py
@@ -186,7 +186,7 @@ def convert_range_member_to_struct(member_spec):
     # Error checking that only one member type was defined
     opts = set(member_spec.keys()).intersection(['member', 'failover_association', 'ms_server'])
     if len(opts) < 1:
-        raise AttributeError("'%s' can not be defined when '%s' is defined!" %(opts[0], opts[1]))
+        raise AttributeError("'%s' can not be defined when '%s' is defined!" % (opts[0], opts[1]))
 
     # A member node was passed in. Ehsure the correct type and struct
     if 'member' in member_spec.keys():

--- a/plugins/module_utils/api.py
+++ b/plugins/module_utils/api.py
@@ -181,6 +181,26 @@ def member_normalize(member_spec):
     return member_spec
 
 
+def convert_members_to_struct(member_spec):
+    ''' Transforms the members list of the Network module arguments into a 
+    valid WAPI struct. This function will change arguments into the valid 
+    wapi structure of the format:
+        {
+            network: 10.1.1.0/24 
+            members:
+                [
+                    {'_struct': 'dhcpmember', 'name': 'member_name1'},
+                    {'_struct': 'dhcpmember', 'name': 'member_name2'}
+                    {'_struct': 'dhcpmember', 'name': '...'}
+                ]
+        }
+    
+    '''
+    if 'members' in member_spec.keys(): 
+        member_spec['members'] = [{'_struct': 'dhcpmember', 'name': k['name']} for k in member_spec['members']]
+    return member_spec 
+
+
 def normalize_ib_spec(ib_spec):
     result = {}
     for arg in ib_spec:
@@ -314,6 +334,9 @@ class WapiModule(WapiBase):
         # checks if the object type is member to normalize the attributes being passed
         if (ib_obj_type == NIOS_MEMBER):
             proposed_object = member_normalize(proposed_object)
+
+        if (ib_obj_type == NIOS_IPV4_NETWORK or ib_obj_type == NIOS_IPV6_NETWORK):
+            proposed_object = convert_members_to_struct(proposed_object)
 
         # checks if the 'text' field has to be updated for the TXT Record
         if (ib_obj_type == NIOS_TXT_RECORD):

--- a/plugins/module_utils/api.py
+++ b/plugins/module_utils/api.py
@@ -52,6 +52,7 @@ NIOS_NETWORK_VIEW = 'networkview'
 NIOS_HOST_RECORD = 'record:host'
 NIOS_IPV4_NETWORK = 'network'
 NIOS_IPV6_NETWORK = 'ipv6network'
+NIOS_RANGE = 'range'
 NIOS_ZONE = 'zone_auth'
 NIOS_PTR_RECORD = 'record:ptr'
 NIOS_A_RECORD = 'record:a'
@@ -198,6 +199,26 @@ def convert_members_to_struct(member_spec):
     '''
     if 'members' in member_spec.keys(): 
         member_spec['members'] = [{'_struct': 'dhcpmember', 'name': k['name']} for k in member_spec['members']]
+    return member_spec 
+
+
+def convert_range_member_to_struct(member_spec):
+    # Error checking that only one member type was defined
+    if len(set(member_spec.keys()).intersection(['member', 'failover_association', 'ms_server'])) < 1:
+        raise AttributeError("'%s' can not be defined when '%s' is defined!" %(opts[0], opts[1]))
+
+    # A member node was passed in. Ehsure the correct type and struct
+    if 'member' in member_spec.keys(): 
+        member_spec['member'] = {'_struct': 'dhcpmember', 'name': member_spec['member']}
+        member_spec['server_association_type'] == 'MEMBER'
+    # A FO association was passed in. Ensure the correct type is set
+    elif 'failover_association' in member_spec.keys(): 
+        member_spec['server_association_type'] == 'FAILOVER'
+    # MS server was passed in. Ensure the correct type and struct
+    elif 'ms_server' in member_spec.keys(): 
+        member_spec['ms_server'] = {'_struct': 'msdhcpserver', 'ipv4addr': member_spec['ms_server']}
+        member_spec['server_association_type'] == 'MS_SERVER'
+
     return member_spec 
 
 

--- a/plugins/module_utils/api.py
+++ b/plugins/module_utils/api.py
@@ -337,8 +337,8 @@ class WapiModule(WapiBase):
         if (ib_obj_type == NIOS_MEMBER):
             proposed_object = member_normalize(proposed_object)
 
-        if (ib_obj_type == NIOS_IPV4_NETWORK or ib_obj_type == NIOS_IPV6_NETWORK):
-            proposed_object = convert_members_to_struct(proposed_object)
+        if (ib_obj_type == NIOS_RANGE):
+            proposed_object = convert_range_member_to_struct(proposed_object)
 
         # checks if the 'text' field has to be updated for the TXT Record
         if (ib_obj_type == NIOS_TXT_RECORD):

--- a/plugins/module_utils/api.py
+++ b/plugins/module_utils/api.py
@@ -32,12 +32,12 @@ __metaclass__ = type
 import json
 import os
 from functools import partial
-from ansible.module_utils._text import to_native
-from ansible.module_utils.six import iteritems
-from ansible.module_utils._text import to_text
-from ansible.module_utils.basic import env_fallback
-from ansible.module_utils.common.validation import check_type_dict, safe_eval
-from ansible.module_utils.six import string_types
+from ..ansible.module_utils._text import to_native
+from ..ansible.module_utils.six import iteritems
+from ..ansible.module_utils._text import to_text
+from ..ansible.module_utils.basic import env_fallback
+from ..ansible.module_utils.common.validation import check_type_dict, safe_eval
+from ..ansible.module_utils.six import string_types
 
 try:
     from infoblox_client.connector import Connector

--- a/plugins/module_utils/api.py
+++ b/plugins/module_utils/api.py
@@ -184,10 +184,8 @@ def member_normalize(member_spec):
 
 def convert_range_member_to_struct(member_spec):
     # Error checking that only one member type was defined
-
-    # BUG - 
     opts = list(set(member_spec.keys()).intersection(['member', 'failover_association', 'ms_server']))
-    if len(opts) < 1:
+    if len(opts) > 1:
         raise AttributeError("'%s' can not be defined when '%s' is defined!" % (opts[0], opts[1]))
 
     # A member node was passed in. Ehsure the correct type and struct

--- a/plugins/module_utils/api.py
+++ b/plugins/module_utils/api.py
@@ -184,7 +184,9 @@ def member_normalize(member_spec):
 
 def convert_range_member_to_struct(member_spec):
     # Error checking that only one member type was defined
-    opts = set(member_spec.keys()).intersection(['member', 'failover_association', 'ms_server'])
+
+    # BUG - 
+    opts = list(set(member_spec.keys()).intersection(['member', 'failover_association', 'ms_server']))
     if len(opts) < 1:
         raise AttributeError("'%s' can not be defined when '%s' is defined!" % (opts[0], opts[1]))
 

--- a/plugins/module_utils/api.py
+++ b/plugins/module_utils/api.py
@@ -182,44 +182,25 @@ def member_normalize(member_spec):
     return member_spec
 
 
-def convert_members_to_struct(member_spec):
-    ''' Transforms the members list of the Network module arguments into a 
-    valid WAPI struct. This function will change arguments into the valid 
-    wapi structure of the format:
-        {
-            network: 10.1.1.0/24 
-            members:
-                [
-                    {'_struct': 'dhcpmember', 'name': 'member_name1'},
-                    {'_struct': 'dhcpmember', 'name': 'member_name2'}
-                    {'_struct': 'dhcpmember', 'name': '...'}
-                ]
-        }
-    
-    '''
-    if 'members' in member_spec.keys(): 
-        member_spec['members'] = [{'_struct': 'dhcpmember', 'name': k['name']} for k in member_spec['members']]
-    return member_spec 
-
-
 def convert_range_member_to_struct(member_spec):
     # Error checking that only one member type was defined
-    if len(set(member_spec.keys()).intersection(['member', 'failover_association', 'ms_server'])) < 1:
+    opts = set(member_spec.keys()).intersection(['member', 'failover_association', 'ms_server'])
+    if len(opts) < 1:
         raise AttributeError("'%s' can not be defined when '%s' is defined!" %(opts[0], opts[1]))
 
     # A member node was passed in. Ehsure the correct type and struct
-    if 'member' in member_spec.keys(): 
+    if 'member' in member_spec.keys():
         member_spec['member'] = {'_struct': 'dhcpmember', 'name': member_spec['member']}
         member_spec['server_association_type'] == 'MEMBER'
     # A FO association was passed in. Ensure the correct type is set
-    elif 'failover_association' in member_spec.keys(): 
+    elif 'failover_association' in member_spec.keys():
         member_spec['server_association_type'] == 'FAILOVER'
     # MS server was passed in. Ensure the correct type and struct
-    elif 'ms_server' in member_spec.keys(): 
+    elif 'ms_server' in member_spec.keys():
         member_spec['ms_server'] = {'_struct': 'msdhcpserver', 'ipv4addr': member_spec['ms_server']}
         member_spec['server_association_type'] == 'MS_SERVER'
 
-    return member_spec 
+    return member_spec
 
 
 def normalize_ib_spec(ib_spec):

--- a/plugins/modules/nios_network.py
+++ b/plugins/modules/nios_network.py
@@ -95,6 +95,17 @@ options:
       - If set to true it'll create the network container to be added or removed
         from the system.
     type: bool
+  members:
+    description:
+      - Configures the Nios Menber assignment for the configured network instance.  
+        This argument accepts a list of member names (see suboptions).
+    type: list
+    elements: dict
+    suboptions:
+      name:
+        description:
+          - The name of the Nios member to be assigned to this network.
+        type: str
   state:
     description:
       - Configures the intended state of the instance of the object on
@@ -124,6 +135,20 @@ EXAMPLES = '''
   infoblox.nios_modules.nios_network:
     network: fe80::/64
     comment: this is a test comment
+    state: present
+    provider:
+      host: "{{ inventory_hostname_short }}"
+      username: admin
+      password: admin
+  connection: local
+
+- name: Create network with member assignment for a network ipv4
+  infoblox.nios_modules.nios_network:
+    network: 192.168.10.0/24
+    comment: this is a test comment
+    members:
+      - name: member1.infoblox
+      - name: member2.infoblox
     state: present
     provider:
       host: "{{ inventory_hostname_short }}"
@@ -289,7 +314,8 @@ def main():
         template=dict(type='str'),
         extattrs=dict(type='dict'),
         comment=dict(),
-        container=dict(type='bool', ib_req=True)
+        container=dict(type='bool', ib_req=True),
+        members=dict(type='list', elements='dict')
     )
 
     argument_spec = dict(

--- a/plugins/modules/nios_network.py
+++ b/plugins/modules/nios_network.py
@@ -97,7 +97,7 @@ options:
     type: bool
   members:
     description:
-      - Configures the Nios Menber assignment for the configured network instance.  
+      - Configures the Nios Menber assignment for the configured network instance.
         This argument accepts a list of member names (see suboptions).
     type: list
     elements: dict

--- a/plugins/modules/nios_network.py
+++ b/plugins/modules/nios_network.py
@@ -95,17 +95,6 @@ options:
       - If set to true it'll create the network container to be added or removed
         from the system.
     type: bool
-  members:
-    description:
-      - Configures the Nios Menber assignment for the configured network instance.
-        This argument accepts a list of member names (see suboptions).
-    type: list
-    elements: dict
-    suboptions:
-      name:
-        description:
-          - The name of the Nios member to be assigned to this network.
-        type: str
   state:
     description:
       - Configures the intended state of the instance of the object on
@@ -135,20 +124,6 @@ EXAMPLES = '''
   infoblox.nios_modules.nios_network:
     network: fe80::/64
     comment: this is a test comment
-    state: present
-    provider:
-      host: "{{ inventory_hostname_short }}"
-      username: admin
-      password: admin
-  connection: local
-
-- name: Create network with member assignment for a network ipv4
-  infoblox.nios_modules.nios_network:
-    network: 192.168.10.0/24
-    comment: this is a test comment
-    members:
-      - name: member1.infoblox
-      - name: member2.infoblox
     state: present
     provider:
       host: "{{ inventory_hostname_short }}"
@@ -312,8 +287,7 @@ def main():
         template=dict(type='str'),
         extattrs=dict(type='dict'),
         comment=dict(),
-        container=dict(type='bool', ib_req=True),
-        members=dict(type='list', elements='dict')
+        container=dict(type='bool', ib_req=True)
     )
 
     argument_spec = dict(

--- a/plugins/modules/nios_range.py
+++ b/plugins/modules/nios_range.py
@@ -114,7 +114,7 @@ options:
   failover_association:
     description:
       - The name of the DHCP failover association which will be configured
-        to server this object instance. A failover of MS or Nios members 
+        to server this object instance. A failover of MS or Nios members
         can be configured. Can not be configured when 'ms_server' or
         'member' are configured.
     type: str
@@ -129,8 +129,8 @@ options:
   server_association_type
     description:
       - Configured the type of server association that will be assigned to
-        serve this object instance. This value is not required and will be 
-        set as needed automatically during module execution. 
+        serve this object instance. This value is not required and will be
+        set as needed automatically during module execution.
     type: str
     required: false
     default: NONE
@@ -155,7 +155,7 @@ options:
 
 EXAMPLES = '''
 
-- name: Configure a ipv4 reserved range 
+- name: Configure a ipv4 reserved range
   infoblox.nios_modules.nios_range:
     network: 192.168.10.0/24
     start: 192.168.10.10
@@ -213,7 +213,6 @@ EXAMPLES = '''
       username: admin
       password: admin
   connection: local
-
 '''
 
 RETURN = ''' # '''
@@ -300,7 +299,8 @@ def main():
 
     argument_spec = dict(
         provider=dict(required=True),
-        state=dict(default='present', choices=['present', 'absent'])
+        state=dict(default='present', 
+                    choices=['present', 'absent'])
     )
 
     argument_spec.update(normalize_ib_spec(ib_spec))

--- a/plugins/modules/nios_range.py
+++ b/plugins/modules/nios_range.py
@@ -91,7 +91,7 @@ options:
       - Configures IP address this object instance is to begin from.
     type: str
     required: true
-    aliases: 
+    aliases:
       - start
       - first_addr
       - first
@@ -100,7 +100,7 @@ options:
       - Configures IP address this object instance is to end at.
     type: str
     required: true
-    aliases: 
+    aliases:
       - end
       - last_addr
       - last
@@ -160,7 +160,7 @@ EXAMPLES = '''
     network: 192.168.10.0/24
     start: 192.168.10.10
     end: 192.168.10.20
-    name: Test Range 1 
+    name: Test Range 1
     comment: this is a test comment
     state: present
     provider:
@@ -174,7 +174,7 @@ EXAMPLES = '''
     network: 192.168.10.0/24
     start: 192.168.10.10
     end: 192.168.10.20
-    name: Test Range 1 
+    name: Test Range 1
     member: infoblox1.localdomain
     comment: this is a test comment
     state: present
@@ -189,7 +189,7 @@ EXAMPLES = '''
     network: 192.168.10.0/24
     start: 192.168.10.10
     end: 192.168.10.20
-    name: Test Range 1 
+    name: Test Range 1
     failover_association: fo_association_01
     comment: this is a test comment
     state: present
@@ -204,7 +204,7 @@ EXAMPLES = '''
     network: 192.168.10.0/24
     start: 192.168.10.10
     end: 192.168.10.20
-    name: Test Range 1 
+    name: Test Range 1
     ms_server: dc01.ad.localdomain
     comment: this is a test comment
     state: present
@@ -290,24 +290,20 @@ def main():
         member=dict(type='str'),
         failover_association=dict(type='str'),
         ms_server=dict(type='str'),
-        server_association_type=dict(type='str',
-                                      default= 'NONE',
-                                      choices=['NONE', 'FAILOVER', 'MEMBER', 'MS_FAILOVER', 'MS_SERVER']),
+        server_association_type=dict(type='str', default= 'NONE', choices=['NONE', 'FAILOVER', 'MEMBER', 'MS_FAILOVER', 'MS_SERVER']),
         extattrs=dict(type='dict'),
         comment=dict()
     )
 
     argument_spec = dict(
         provider=dict(required=True),
-        state=dict(default='present', 
-                    choices=['present', 'absent'])
+        state=dict(default='present', choices=['present', 'absent'])
     )
 
     argument_spec.update(normalize_ib_spec(ib_spec))
     argument_spec.update(WapiModule.provider_spec)
 
-    module = AnsibleModule(argument_spec=argument_spec,
-                           supports_check_mode=True)
+    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True)
 
     wapi = WapiModule(module)
     # to check for vendor specific dhcp option

--- a/plugins/modules/nios_range.py
+++ b/plugins/modules/nios_range.py
@@ -12,7 +12,6 @@ module: nios_range
 author: "Matthew Dennett (@matthewdennett)"
 short_description: Configure Infoblox NIOS network range object
 version_added: "1.0.0"
-
 description:
   - Adds and/or removes instances of range objects from
     Infoblox NIOS servers.  This module manages NIOS DHCP range objects

--- a/plugins/modules/nios_range.py
+++ b/plugins/modules/nios_range.py
@@ -298,8 +298,8 @@ def main():
         member=dict(type='str'),
         failover_association=dict(type='str'),
         ms_server=dict(type='str'),
-        server_association_type=dict(type='str', 
-                                      default= 'NONE', 
+        server_association_type=dict(type='str',
+                                      default= 'NONE',
                                       choices=['NONE', 'FAILOVER', 'MEMBER', 'MS_FAILOVER', 'MS_SERVER']),
         extattrs=dict(type='dict'),
         comment=dict()

--- a/plugins/modules/nios_range.py
+++ b/plugins/modules/nios_range.py
@@ -11,7 +11,7 @@ DOCUMENTATION = '''
 module: nios_range
 author: "Matthew Dennett (@matthewdennett)"
 short_description: Configure Infoblox NIOS network range object
-version_added: "1.3.1"
+version_added: "1.4.0"
 description:
   - Adds and/or removes instances of range objects from
     Infoblox NIOS servers.  This module manages NIOS DHCP range objects
@@ -30,7 +30,6 @@ options:
     type: str
     required: true
     aliases:
-      - name
       - cidr
   network_view:
     description:
@@ -125,7 +124,7 @@ options:
         'failover_association' are configured.
     type: str
     required: false
-  server_association_type
+  server_association_type:
     description:
       - Configured the type of server association that will be assigned to
         serve this object instance. This value is not required and will be
@@ -150,6 +149,18 @@ options:
     choices:
       - present
       - absent
+  disable:
+    description:
+      - Configures the enabled of discbeled for DHCP state for the instance
+        of the object on the NIOS server. When this value is set to true, the
+        object is configured in the disabled for DHCP state.
+    type: bool
+    default: false
+  name:
+    description:
+      - Congifured the name of the Microsoft scope for the instance of the
+        object on the NIOS server.
+    type: str
 '''
 
 EXAMPLES = '''
@@ -277,19 +288,17 @@ def main():
 
     # This is what gets posted to the WAPI API
     ib_spec = dict(
-        network=dict(required=True, aliases=['name', 'cidr']),
+        network=dict(required=True, aliases=['cidr']),
         network_view=dict(default='default', ib_req=True),
-
         start_addr=dict(required=True, aliases=['start', 'first_addr', 'first'], type='str', ib_req=True),
         end_addr=dict(required=True, aliases=['end', 'last_addr', 'last'], type='str', ib_req=True),
         name=dict(type='str'),
         disable=dict(type='bool', default='false',),
         options=dict(type='list', elements='dict', options=option_spec, transform=options),
-        # template=dict(type='str'),
         member=dict(type='str'),
         failover_association=dict(type='str'),
         ms_server=dict(type='str'),
-        server_association_type=dict(type='str', default='NONE', choices=['NONE', 'FAILOVER', 'MEMBER', 'MS_FAILOVER', 'MS_SERVER']),
+        server_association_type=dict(type='str', default='NONE', choices=['NONE', 'FAILOVER', 'MEMBER', 'FAILOVER_MS', 'MS_SERVER']),
         extattrs=dict(type='dict'),
         comment=dict()
     )

--- a/plugins/modules/nios_range.py
+++ b/plugins/modules/nios_range.py
@@ -209,7 +209,7 @@ EXAMPLES = '''
       password: admin
   connection: local
 
-- name: Configure a ipv4 range served by a failover association
+- name: Configure a ipv4 range served by a MS Server
   infoblox.nios_modules.nios_range:
     network: 192.168.10.0/24
     start: 192.168.10.10

--- a/plugins/modules/nios_range.py
+++ b/plugins/modules/nios_range.py
@@ -1,0 +1,329 @@
+#!/usr/bin/python
+# Copyright (c) 2018-2019 Red Hat, Inc.
+# Copyright (c) 2020 Infoblox, Inc.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+DOCUMENTATION = '''
+---
+module: nios_range
+author: "Matthew Dennett (@matthewdennett)"
+short_description: Configure Infoblox NIOS network range object
+version_added: "1.0.0"
+
+description:
+  - Adds and/or removes instances of range objects from
+    Infoblox NIOS servers.  This module manages NIOS DHCP range objects
+    using the Infoblox WAPI interface over REST.
+  - Supports both IPV4 and IPV6 internet protocols.
+requirements:
+  - infoblox-client
+extends_documentation_fragment: infoblox.nios_modules.nios
+notes:
+    - This module supports C(check_mode).
+options:
+  network:
+    description:
+      - Specifies the network to add or remove DHCP range to.  The value
+        should use CIDR notation.
+    type: str
+    required: true
+    aliases:
+      - name
+      - cidr
+  network_view:
+    description:
+      - Configures the name of the network view to associate with this
+        configured instance.
+    type: str
+    default: default
+  options:
+    description:
+      - Configures the set of DHCP options to be included as part of
+        the configured network instance.  This argument accepts a list
+        of values (see suboptions).  When configuring suboptions at
+        least one of C(name) or C(num) must be specified.
+    type: list
+    elements: dict
+    suboptions:
+      name:
+        description:
+          - The name of the DHCP option to configure. The standard options are
+            C(router), C(router-templates), C(domain-name-servers), C(domain-name),
+            C(broadcast-address), C(broadcast-address-offset), C(dhcp-lease-time),
+            and C(dhcp6.name-servers).
+        type: str
+      num:
+        description:
+          - The number of the DHCP option to configure
+        type: int
+      value:
+        description:
+          - The value of the DHCP option specified by C(name)
+        type: str
+        required: true
+      use_option:
+        description:
+          - Only applies to a subset of options (see NIOS API documentation)
+        type: bool
+        default: 'yes'
+      vendor_class:
+        description:
+          - The name of the space this DHCP option is associated to
+        type: str
+        default: DHCP
+  extattrs:
+    description:
+      - Allows for the configuration of Extensible Attributes on the
+        instance of the object.  This argument accepts a set of key / value
+        pairs for configuration.
+    type: dict
+  comment:
+    description:
+      - Configures a text string comment to be associated with the instance
+        of this object.  The provided text string will be configured on the
+        object instance.
+    type: str
+
+  start_addr:
+    description:
+      - Configures IP address this object instance is to begin from.
+    type: str
+    required: true
+    aliases: 
+      - start
+      - first_addr
+      - first
+
+  end_addr:
+    description:
+      - Configures IP address this object instance is to end at.
+    type: str
+    required: true
+    aliases: 
+      - end
+      - last_addr
+      - last
+
+  member:
+    description:
+      - The hostname of the Nios member which will be configured to server
+        this object instance. Can not be configured when 'ms_server' or
+        'failover_association' are configured.
+    type: str
+    required: false
+
+  failover_association:
+    description:
+      - The name of the DHCP failover association which will be configured
+        to server this object instance. A failover of MS or Nios members 
+        can be configured. Can not be configured when 'ms_server' or
+        'member' are configured.
+    type: str
+    required: false
+
+  ms_server:
+    description:
+      - The hostname of the MS member which will be configured to server
+        this object instance. Can not be configured when 'member' or
+        'failover_association' are configured.
+    type: str
+    required: false
+
+  server_association_type
+    description:
+      - Configured the type of server association that will be assigned to
+        serve this object instance. This value is not required and will be 
+        set as needed automatically during module execution. 
+    type: str
+    required: false
+    default: NONE
+    choices:
+      - NONE
+      - FAILOVER
+      - MEMBER
+      - FAILOVER_MS
+      - MS_SERVER
+
+  state:
+    description:
+      - Configures the intended state of the instance of the object on
+        the NIOS server.  When this value is set to C(present), the object
+        is configured on the device and when this value is set to C(absent)
+        the value is removed (if necessary) from the device.
+    type: str
+    default: present
+    choices:
+      - present
+      - absent
+'''
+
+EXAMPLES = '''
+
+- name: Configure a ipv4 reserved range 
+  infoblox.nios_modules.nios_range:
+    network: 192.168.10.0/24
+    start: 192.168.10.10
+    end: 192.168.10.20
+    name: Test Range 1 
+    comment: this is a test comment
+    state: present
+    provider:
+      host: "{{ inventory_hostname_short }}"
+      username: admin
+      password: admin
+  connection: local
+
+- name: Configure a ipv4 range served by a member
+  infoblox.nios_modules.nios_range:
+    network: 192.168.10.0/24
+    start: 192.168.10.10
+    end: 192.168.10.20
+    name: Test Range 1 
+    member: infoblox1.localdomain
+    comment: this is a test comment
+    state: present
+    provider:
+      host: "{{ inventory_hostname_short }}"
+      username: admin
+      password: admin
+  connection: local
+
+- name: Configure a ipv4 range served by a failover association
+  infoblox.nios_modules.nios_range:
+    network: 192.168.10.0/24
+    start: 192.168.10.10
+    end: 192.168.10.20
+    name: Test Range 1 
+    failover_association: fo_association_01
+    comment: this is a test comment
+    state: present
+    provider:
+      host: "{{ inventory_hostname_short }}"
+      username: admin
+      password: admin
+  connection: local
+
+- name: Configure a ipv4 range served by a failover association
+  infoblox.nios_modules.nios_range:
+    network: 192.168.10.0/24
+    start: 192.168.10.10
+    end: 192.168.10.20
+    name: Test Range 1 
+    ms_server: dc01.ad.localdomain
+    comment: this is a test comment
+    state: present
+    provider:
+      host: "{{ inventory_hostname_short }}"
+      username: admin
+      password: admin
+  connection: local
+
+'''
+
+RETURN = ''' # '''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.six import iteritems
+from module_utils.api import WapiModule
+from module_utils.api import NIOS_RANGE
+from module_utils.api import normalize_ib_spec
+
+
+def options(module):
+    ''' Transforms the module argument into a valid WAPI struct
+    This function will transform the options argument into a structure that
+    is a valid WAPI structure in the format of:
+        {
+            name: <value>,
+            num: <value>,
+            value: <value>,
+            use_option: <value>,
+            vendor_class: <value>
+        }
+    It will remove any options that are set to None since WAPI will error on
+    that condition.  It will also verify that either `name` or `num` is
+    set in the structure but does not validate the values are equal.
+    The remainder of the value validation is performed by WAPI
+    '''
+    options = list()
+    for item in module.params['options']:
+        opt = dict([(k, v) for k, v in iteritems(item) if v is not None])
+        if 'name' not in opt and 'num' not in opt:
+            module.fail_json(msg='one of `name` or `num` is required for option value')
+        options.append(opt)
+    return options
+
+
+def check_vendor_specific_dhcp_option(module, ib_spec):
+    '''This function will check if the argument dhcp option belongs to vendor-specific and if yes then will remove
+     use_options flag which is not supported with vendor-specific dhcp options.
+    '''
+    for key, value in iteritems(ib_spec):
+        if isinstance(module.params[key], list):
+            for temp_dict in module.params[key]:
+                if 'num' in temp_dict:
+                    if temp_dict['num'] in (43, 124, 125, 67, 60):
+                        del temp_dict['use_option']
+    return ib_spec
+
+
+def main():
+    ''' Main entry point for module execution
+    '''
+    option_spec = dict(
+        # one of name or num is required; enforced by the function options()
+        name=dict(),
+        num=dict(type='int'),
+
+        value=dict(required=True),
+
+        use_option=dict(type='bool', default=True),
+        vendor_class=dict(default='DHCP')
+    )
+
+    # This is what gets posted to the WAPI API
+    ib_spec = dict(
+        network=dict(required=True, aliases=['name', 'cidr']),
+        network_view=dict(default='default', ib_req=True),
+
+        start_addr=dict(required=True, aliases=['start', 'first_addr', 'first'], type='str', ib_req=True),
+        end_addr=dict(required=True, aliases=['end', 'last_addr', 'last'], type='str', ib_req=True),
+        name=dict(type='str'),
+        disable=dict(type='bool', default='false',),
+        options=dict(type='list', elements='dict', options=option_spec, transform=options),
+        # template=dict(type='str'),
+        member=dict(type='str'),
+        failover_association=dict(type='str'),
+        ms_server=dict(type='str'),
+        server_association_type=dict(type='str', 
+                                      default= 'NONE', 
+                                      choices=['NONE', 'FAILOVER', 'MEMBER', 'MS_FAILOVER', 'MS_SERVER']),
+        extattrs=dict(type='dict'),
+        comment=dict()
+    )
+
+    argument_spec = dict(
+        provider=dict(required=True),
+        state=dict(default='present', choices=['present', 'absent'])
+    )
+
+    argument_spec.update(normalize_ib_spec(ib_spec))
+    argument_spec.update(WapiModule.provider_spec)
+
+    module = AnsibleModule(argument_spec=argument_spec,
+                           supports_check_mode=True)
+
+    wapi = WapiModule(module)
+    # to check for vendor specific dhcp option
+    ib_spec = check_vendor_specific_dhcp_option(module, ib_spec)
+
+    result = wapi.run(NIOS_RANGE, ib_spec)
+
+    module.exit_json(**result)
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/nios_range.py
+++ b/plugins/modules/nios_range.py
@@ -11,7 +11,7 @@ DOCUMENTATION = '''
 module: nios_range
 author: "Matthew Dennett (@matthewdennett)"
 short_description: Configure Infoblox NIOS network range object
-version_added: "1.0.0"
+version_added: "1.3.1"
 description:
   - Adds and/or removes instances of range objects from
     Infoblox NIOS servers.  This module manages NIOS DHCP range objects
@@ -289,7 +289,7 @@ def main():
         member=dict(type='str'),
         failover_association=dict(type='str'),
         ms_server=dict(type='str'),
-        server_association_type=dict(type='str', default= 'NONE', choices=['NONE', 'FAILOVER', 'MEMBER', 'MS_FAILOVER', 'MS_SERVER']),
+        server_association_type=dict(type='str', default='NONE', choices=['NONE', 'FAILOVER', 'MEMBER', 'MS_FAILOVER', 'MS_SERVER']),
         extattrs=dict(type='dict'),
         comment=dict()
     )

--- a/plugins/modules/nios_range.py
+++ b/plugins/modules/nios_range.py
@@ -86,7 +86,6 @@ options:
         of this object.  The provided text string will be configured on the
         object instance.
     type: str
-
   start_addr:
     description:
       - Configures IP address this object instance is to begin from.
@@ -96,7 +95,6 @@ options:
       - start
       - first_addr
       - first
-
   end_addr:
     description:
       - Configures IP address this object instance is to end at.
@@ -106,7 +104,6 @@ options:
       - end
       - last_addr
       - last
-
   member:
     description:
       - The hostname of the Nios member which will be configured to server
@@ -114,7 +111,6 @@ options:
         'failover_association' are configured.
     type: str
     required: false
-
   failover_association:
     description:
       - The name of the DHCP failover association which will be configured
@@ -123,7 +119,6 @@ options:
         'member' are configured.
     type: str
     required: false
-
   ms_server:
     description:
       - The hostname of the MS member which will be configured to server
@@ -131,7 +126,6 @@ options:
         'failover_association' are configured.
     type: str
     required: false
-
   server_association_type
     description:
       - Configured the type of server association that will be assigned to
@@ -146,7 +140,6 @@ options:
       - MEMBER
       - FAILOVER_MS
       - MS_SERVER
-
   state:
     description:
       - Configures the intended state of the instance of the object on

--- a/plugins/modules/nios_range.py
+++ b/plugins/modules/nios_range.py
@@ -227,9 +227,9 @@ RETURN = ''' # '''
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.six import iteritems
-from module_utils.api import WapiModule
-from module_utils.api import NIOS_RANGE
-from module_utils.api import normalize_ib_spec
+from ..module_utils.api import WapiModule
+from ..module_utils.api import NIOS_RANGE
+from ..module_utils.api import normalize_ib_spec
 
 
 def options(module):


### PR DESCRIPTION
This MR aims to add the functionality to manage Nios Network range objects. 

Some modification of the ranged member definition was required for it to alight with what the API expects. This is done with the addition of a function in the api.py file.  `def convert_range_member_to_struct(member_spec):`