### PR TITLE
Enforce selecting ref from network_obj based on network view

### DIFF
--- a/plugins/lookup/nios_next_ip.py
+++ b/plugins/lookup/nios_next_ip.py
@@ -33,12 +33,21 @@ options:
       required: false
       type: list
       elements: str
+    network_view:
+      description: The network view to retrieve the CIDR network from.
+      required: false
+      default: default
+      type: str
 '''
 
 EXAMPLES = """
 - name: return next available IP address for network 192.168.10.0/24
   ansible.builtin.set_fact:
     ipaddr: "{{ lookup('infoblox.nios_modules.nios_next_ip', '192.168.10.0/24', provider={'host': 'nios01', 'username': 'admin', 'password': 'password'}) }}"
+
+- name: return next available IP address for network 192.168.10.0/24 in a non-default network view
+  ansible.builtin.set_fact:
+    ipaddr: "{{ lookup('infoblox.nios_modules.nios_next_ip', '192.168.10.0/24', network_view='ansible', provider={'host': 'nios01', 'username': 'admin', 'password': 'password'}) }}"
 
 - name: return the next 3 available IP addresses for network 192.168.10.0/24
   ansible.builtin.set_fact:
@@ -91,9 +100,10 @@ class LookupModule(LookupBase):
 
         num = kwargs.get('num', 1)
         exclude_ip = kwargs.get('exclude', [])
+        network_view = kwargs.get('network_view', 'default')
 
         try:
-            ref = network_obj[0]['_ref']
+            ref = [network['_ref'] for network in network_obj if network['network_view'] == network_view][0]
             avail_ips = wapi.call_func('next_available_ip', ref, {'num': num, 'exclude': exclude_ip})
             return [avail_ips['ips']]
         except Exception as exc:

--- a/plugins/lookup/nios_next_network.py
+++ b/plugins/lookup/nios_next_network.py
@@ -41,12 +41,22 @@ options:
       default: ''
       type: list
       elements: str
+    network_view:
+      description: The network view to retrieve the CIDR network from.
+      required: false
+      default: default
+      type: str
 '''
 
 EXAMPLES = """
 - name: return next available network for network-container 192.168.10.0/24
   ansible.builtin.set_fact:
     networkaddr: "{{ lookup('infoblox.nios_modules.nios_next_network', '192.168.10.0/24', cidr=25,
+                        provider={'host': 'nios01', 'username': 'admin', 'password': 'password'}) }}"
+
+- name: return next available network for network-container 192.168.10.0/24 in a non-default network view
+  ansible.builtin.set_fact:
+    networkaddr: "{{ lookup('infoblox.nios_modules.nios_next_network', '192.168.10.0/24', cidr=25, network_view='ansible'
                         provider={'host': 'nios01', 'username': 'admin', 'password': 'password'}) }}"
 
 - name: return the next 2 available network addresses for network-container 192.168.10.0/24
@@ -94,9 +104,10 @@ class LookupModule(LookupBase):
             raise AnsibleError('unable to find network-container object %s' % network)
         num = kwargs.get('num', 1)
         exclude_ip = kwargs.get('exclude', [])
+        network_view = kwargs.get('network_view', 'default')
 
         try:
-            ref = network_obj[0]['_ref']
+            ref = [network['_ref'] for network in network_obj if network['network_view'] == network_view][0]
             avail_nets = wapi.call_func('next_available_network', ref, {'cidr': cidr, 'num': num, 'exclude': exclude_ip})
             return [avail_nets['networks']]
         except Exception as exc:


### PR DESCRIPTION
Since there can be multiple network views containing the same networks, we need to ensure that the correct network in the `network_obj` list is picked based on a network view name, instead of simply taking it from the first one in the list. The 'default' view is used by default.

Fixes: #156