### PR TITLE
Fix the 1.4.0 major changes changelog

### DIFF
--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -185,7 +185,7 @@ releases:
   1.4.0:
     changes:
       major_changes:
-      - Feature for extra layer security , with `cert` and `key` parameters in playbooks for authenticating using certificate and key *.pem file absolute path `#154 <https://github.com/infobloxopen/infoblox-ansible/pull/154>`_
+      - Feature for extra layer security , with `cert` and `key` parameters in playbooks for authenticating using certificate and key ``*.pem`` file absolute path `#154 <https://github.com/infobloxopen/infoblox-ansible/pull/154>`_
       - Fix to remove issue causing due to template attr in deleting network using Ansible module nios network `#147 <https://github.com/infobloxopen/infoblox-ansible/pull/147>`_
       release_summary:
       - For ansible module, added certificate authentication feature


### PR DESCRIPTION
This line is breaking the Ansible porting guide CI. It is seeing the first * and assuming this is a bold syntax and the ending * is missing.  Adding backticks around this so the ansible/ansible CI understands the sentence.

This PR is required for Ansible 7 and will thus mean I think that this collection needs to spin a new release as soon as possible.