### PR TITLE
Fix to changelog and lookup modules

### DIFF
--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -113,11 +113,10 @@ releases:
       - Sanity fixes as per Ansible guidelines to all modules
       minor_changes:
       - The modules are standardized as per Ansible guidelines
-      release_summary:
-      - Support for creating IPv6 Fixed Address with DUID
-      - Support added to return the next available IP address for an IPv6 network
-      - Modules made compatible to work with ansible-core 2.11
-      - Issue fixes and standardization of modules as per Ansible guidelines
+      release_summary: 'Support for creating IPv6 Fixed Address with DUID,
+        Support added to return the next available IP address for an IPv6 network,
+        Modules made compatible to work with ansible-core 2.11,
+        Issue fixes and standardization of modules as per Ansible guidelines'
     release_date: '2021-09-07'
   1.1.2:
     changes:
@@ -127,9 +126,8 @@ releases:
       minor_changes:
       - Changes in inventory and lookup plugins documentation `#85 <https://github.com/infobloxopen/infoblox-ansible/pull/85>`_
       - Directory restructure and added integration & unit tests `#87 <https://github.com/infobloxopen/infoblox-ansible/pull/87>`_
-      release_summary:
-      - Issue fixes and standardization of inventory plugin and lookup modules as per Ansible guidelines
-      - Directory restructure and added integration & unit tests
+      release_summary: 'Issue fixes and standardization of inventory plugin and lookup modules as per Ansible guidelines,
+        Directory restructure and added integration & unit tests'
     release_date: '2021-10-12'
   1.2.0:
     changes:
@@ -146,16 +144,15 @@ releases:
         | CNAME | canonical |
         | MX | mail_exchanger, preference |
         | PTR | ptrdname |
-      release_summary:
-      - Issue fixes to update A Record using 'next_available_ip' function
-      - Added a new feature - Update canonical name of the CNAME Record
-      - Updated the 'required' fields in modules 
+      release_summary: 'Issue fixes to update A Record using `next_available_ip` function,
+        Added a new feature - Update canonical name of the CNAME Record,
+        Updated the `required` fields in modules'
     release_date: '2021-12-13'
   1.2.1:
     changes:
       minor_changes:
       - Added tags 'cloud' and 'networking' in 'galaxy.yaml'
-      release_summary: Added tags to support release on Ansible Automation Hub
+      release_summary: 'Added tags to support release on Ansible Automation Hub'
     release_date: '2021-12-20'
 
   1.2.2:
@@ -166,28 +163,25 @@ releases:
       - Allow specifying a template when creating a network `#105 <https://github.com/infobloxopen/infoblox-ansible/pull/105>`_
       - Fix unit and sanity test issues `#117 <https://github.com/infobloxopen/infoblox-ansible/pull/117>`_
       - Expanding for disable value `#119 <https://github.com/infobloxopen/infoblox-ansible/pull/119>`_
-      release_summary: 
-      - Issue fixes to create PTR record in different network views
-      - Support extended to determine whether the DTC server is disabled or not
+      release_summary: 'Issue fixes to create PTR record in different network views,
+        Support extended to determine whether the DTC server is disabled or not'
     release_date: '2022-05-23'
   1.3.0:
     changes:
       major_changes:
       - Update operation using `old_name` and `new_name` for the object with dummy name in `old_name` (which does not exist in system) will not create a new object in the system. An error will be thrown stating the object does not exist in the system `#129 <https://github.com/infobloxopen/infoblox-ansible/pull/129>`_
       - Update `text` field of TXT Record `#128 <https://github.com/infobloxopen/infoblox-ansible/pull/128>`_
-      bug_fixes:
+      bugfixes:
       - Fix to create TXT record with equals sign `#128 <https://github.com/infobloxopen/infoblox-ansible/pull/128>`_
-      release_summary:
-      - Issue fixes to create TXT record with equals sign
-      - For nonexistent record, update operation creates the new record
-      - For nonexistent IPv4Address, update operation creates a new A record with new_ipv4addr
+      release_summary: 'Issue fixes to create TXT record with equals sign,
+        For nonexistent record, update operation creates the new record,
+        For nonexistent IPv4Address, update operation creates a new A record with new_ipv4addr'
     release_date: '2022-07-01'
   1.4.0:
     changes:
       major_changes:
       - Feature for extra layer security , with `cert` and `key` parameters in playbooks for authenticating using certificate and key ``*.pem`` file absolute path `#154 <https://github.com/infobloxopen/infoblox-ansible/pull/154>`_
       - Fix to remove issue causing due to template attr in deleting network using Ansible module nios network `#147 <https://github.com/infobloxopen/infoblox-ansible/pull/147>`_
-      release_summary:
-      - For ansible module, added certificate authentication feature
-      - Few bugs fix in ansible module nios network
+      release_summary: 'For ansible module, added certificate authentication feature,
+        Few bugs fix in ansible module nios network'
     release_date: '2022-10-12'

--- a/plugins/lookup/nios_next_ip.py
+++ b/plugins/lookup/nios_next_ip.py
@@ -47,7 +47,8 @@ EXAMPLES = """
 
 - name: return next available IP address for network 192.168.10.0/24 in a non-default network view
   ansible.builtin.set_fact:
-    ipaddr: "{{ lookup('infoblox.nios_modules.nios_next_ip', '192.168.10.0/24', network_view='ansible', provider={'host': 'nios01', 'username': 'admin', 'password': 'password'}) }}"
+    ipaddr: "{{ lookup('infoblox.nios_modules.nios_next_ip', '192.168.10.0/24', network_view='ansible', \
+                provider={'host': 'nios01', 'username': 'admin', 'password': 'password'}) }}"
 
 - name: return the next 3 available IP addresses for network 192.168.10.0/24
   ansible.builtin.set_fact:
@@ -103,7 +104,11 @@ class LookupModule(LookupBase):
         network_view = kwargs.get('network_view', 'default')
 
         try:
-            ref = [network['_ref'] for network in network_obj if network['network_view'] == network_view][0]
+            ref_list = [network['_ref'] for network in network_obj if network['network_view'] == network_view]
+            if not ref_list:
+                raise AnsibleError('no records found')
+            else:
+                ref = ref_list[0]
             avail_ips = wapi.call_func('next_available_ip', ref, {'num': num, 'exclude': exclude_ip})
             return [avail_ips['ips']]
         except Exception as exc:

--- a/plugins/lookup/nios_next_network.py
+++ b/plugins/lookup/nios_next_network.py
@@ -107,7 +107,11 @@ class LookupModule(LookupBase):
         network_view = kwargs.get('network_view', 'default')
 
         try:
-            ref = [network['_ref'] for network in network_obj if network['network_view'] == network_view][0]
+            ref_list = [network['_ref'] for network in network_obj if network['network_view'] == network_view]
+            if not ref_list:
+                raise AnsibleError('no records found')
+            else:
+                ref = ref_list[0]
             avail_nets = wapi.call_func('next_available_network', ref, {'cidr': cidr, 'num': num, 'exclude': exclude_ip})
             return [avail_nets['networks']]
         except Exception as exc:

--- a/plugins/modules/nios_nsgroup.py
+++ b/plugins/modules/nios_nsgroup.py
@@ -405,7 +405,7 @@ def main():
         enable_preferred_primaries=dict(type='bool', default=False),
         grid_replicate=dict(type='bool', default=False),
         lead=dict(type='bool', default=False),
-        preferred_primaries=dict(type='list', elements='dict', options=extserver_spec, default=[]),
+        preferred_primaries=dict(type='list', elements='dict', options=extserver_spec, default=None),
         stealth=dict(type='bool', default=False),
     )
 

--- a/tests/unit/requirements.txt
+++ b/tests/unit/requirements.txt
@@ -1,5 +1,6 @@
 infoblox-client
 pytest
+pytest-forked
 pytest-xdist
 mock
 pytest-mock


### PR DESCRIPTION
This fix contains changes in changelogs.yaml and with lookup modules containing nios_next_ip.py and nios_next_network.py for returning ansible error as no records found if ref list is empty in both modules