### PR TITLE
Fix for nios_a_record and nios_network_view

### DIFF
--- a/plugins/module_utils/api.py
+++ b/plugins/module_utils/api.py
@@ -533,7 +533,7 @@ class WapiModule(WapiBase):
             # gets and returns the current object based on name/old_name passed
             try:
                 name_obj = check_type_dict(obj_filter['name'])
-                #check if network_view allows searching and updating with camelCase
+                # check if network_view allows searching and updating with camelCase
                 if (ib_obj_type == NIOS_NETWORK_VIEW):
                     old_name = name_obj['old_name']
                     new_name = name_obj['new_name']

--- a/plugins/module_utils/api.py
+++ b/plugins/module_utils/api.py
@@ -533,8 +533,13 @@ class WapiModule(WapiBase):
             # gets and returns the current object based on name/old_name passed
             try:
                 name_obj = check_type_dict(obj_filter['name'])
-                old_name = name_obj['old_name'].lower()
-                new_name = name_obj['new_name'].lower()
+                #check if network_view allows searching and updating with camelCase
+                if (ib_obj_type == NIOS_NETWORK_VIEW):
+                    old_name = name_obj['old_name']
+                    new_name = name_obj['new_name']
+                else:
+                    old_name = name_obj['old_name'].lower()
+                    new_name = name_obj['new_name'].lower()
             except TypeError:
                 name = obj_filter['name']
 
@@ -573,7 +578,7 @@ class WapiModule(WapiBase):
                 try:
                     ipaddr_obj = check_type_dict(obj_filter['ipv4addr'])
                     ipaddr = ipaddr_obj.get('old_ipv4addr')
-                    old_ipv4addr_exists = True
+                    old_ipv4addr_exists = True if ipaddr else False
                 except TypeError:
                     ipaddr = obj_filter['ipv4addr']
                 test_obj_filter['ipv4addr'] = ipaddr
@@ -615,7 +620,7 @@ class WapiModule(WapiBase):
             try:
                 ipaddr_obj = check_type_dict(obj_filter['ipv4addr'])
                 ipaddr = ipaddr_obj.get('old_ipv4addr')
-                old_ipv4addr_exists = True
+                old_ipv4addr_exists = True if ipaddr else False
             except TypeError:
                 ipaddr = obj_filter['ipv4addr']
             test_obj_filter['ipv4addr'] = ipaddr


### PR DESCRIPTION
Previously nios_network_view was failing to update the network_view new_name with camelCase from old_name with lowercase. And nios_a_record is having issue with dynamically add a record with next available ip, this fix will work till infoblox-client version 0.5.0 but this change fails for the above versions 