### PR TITLE
Dropped Version 2.7 in Unit Tests

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -48,17 +48,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [2.7, 3.8, 3.9]
+        python-version: [3.8, 3.9]
         ansible-version: [stable-2.9, stable-2.10, stable-2.11, stable-2.12, stable-2.13, devel]
         exclude:
           - ansible-version: devel
-            python-version: 2.7
-          - ansible-version: devel
             python-version: 3.8
-          - ansible-version: stable-2.12
-            python-version: 2.7 
-          - ansible-version: stable-2.13
-            python-version: 2.7
           - ansible-version: stable-2.9
             python-version: 3.9
 


### PR DESCRIPTION
This includes to drop the 2.7 in the Unit tests, as it is no more supported