### PR TITLE
Bugfix/second record with same name option 1

### DIFF
--- a/changelogs/fragments/two_hostrecords_same_hostname.yml
+++ b/changelogs/fragments/two_hostrecords_same_hostname.yml
@@ -1,2 +1,2 @@
-- bugfixes:
+bugfixes:
   - nios_host_record - "if len(ib_obj_ref) > 1" in module_utils/api.py results in weird behaviour. Adding "or (len(ib_obj_ref) >= 1 and ib_obj_type == NIOS_HOST_RECORD)" to the if-statement results in the wanted behaviour.

--- a/changelogs/fragments/two_hostrecords_same_hostname.yml
+++ b/changelogs/fragments/two_hostrecords_same_hostname.yml
@@ -1,0 +1,2 @@
+- bugfixes:
+  - nios_host_record - "if len(ib_obj_ref) > 1" in module_utils/api.py results in weird behaviour. Adding "or (len(ib_obj_ref) >= 1 and ib_obj_type == NIOS_HOST_RECORD)" to the if-statement results in the wanted behaviour.

--- a/plugins/module_utils/api.py
+++ b/plugins/module_utils/api.py
@@ -326,7 +326,7 @@ class WapiModule(WapiBase):
             del proposed_object['view']
 
         if ib_obj_ref:
-            if len(ib_obj_ref) > 1:
+            if len(ib_obj_ref) > 1 or (len(ib_obj_ref) >= 1 and ib_obj_type == NIOS_HOST_RECORD):
                 for each in ib_obj_ref:
                     # To check for existing A_record with same name with input A_record by IP
                     if each.get('ipv4addr') and each.get('ipv4addr') == proposed_object.get('ipv4addr'):

--- a/two_hostrecords_same_name.yml
+++ b/two_hostrecords_same_name.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - nios_host_record - "if len(ib_obj_ref) > 1" in module_utils/api.py results in weird behaviour. Adding "or (len(ib_obj_ref) >= 1 and ib_obj_type == NIOS_HOST_RECORD)" to the if-statement results in the wanted behaviour.

--- a/two_hostrecords_same_name.yml
+++ b/two_hostrecords_same_name.yml
@@ -1,2 +1,0 @@
-bugfixes:
-  - nios_host_record - "if len(ib_obj_ref) > 1" in module_utils/api.py results in weird behaviour. Adding "or (len(ib_obj_ref) >= 1 and ib_obj_type == NIOS_HOST_RECORD)" to the if-statement results in the wanted behaviour.


### PR DESCRIPTION
I am developing an Ansible Playbook automating IPAM.
While using the infoblox.nios_modules I noticed a weird behaviour. After creating a hostrecord with an IP-address x and a hostname, I executed the playbook again now with a different IP-address y and the same hostname. The secon hostrecord was placed in the IP-Adress y but also the first hostrecord was placed there. Also the extra attributes of the first hostrecord changed.

This was already described in #108 

I fixed the problem in the commit 58cb936c8e76bd71280af3e5c70f55ca31ddd6fe. This only fixes the problem if the if_obj_type is "NIOS_HOST_RECORD". 
A general fix is going to be given in the PR: Bugfix/second record with same name option 2. I can not forsee if the general fix influences any other use case though.