### PR TITLE
Bugfix/second hostrecord with same hostname option 2

### DIFF
--- a/changelogs/fragments/two_hostrecords_same_hostname.yml
+++ b/changelogs/fragments/two_hostrecords_same_hostname.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - nios_host_record - "if len(ib_obj_ref) > 1" in module_utils/api.py results in weird behaviour. Changed to "if len(ib_obj_ref) >= 1" and deleted the corresponding else-statement.

--- a/plugins/module_utils/api.py
+++ b/plugins/module_utils/api.py
@@ -326,7 +326,7 @@ class WapiModule(WapiBase):
             del proposed_object['view']
 
         if ib_obj_ref:
-            if len(ib_obj_ref) > 1:
+            if len(ib_obj_ref) >= 1:
                 for each in ib_obj_ref:
                     # To check for existing A_record with same name with input A_record by IP
                     if each.get('ipv4addr') and each.get('ipv4addr') == proposed_object.get('ipv4addr'):
@@ -340,8 +340,6 @@ class WapiModule(WapiBase):
                     else:
                         current_object = obj_filter
                         ref = None
-            else:
-                current_object = ib_obj_ref[0]
             if 'extattrs' in current_object:
                 current_object['extattrs'] = flatten_extattrs(current_object['extattrs'])
             if current_object.get('_ref'):


### PR DESCRIPTION
I am developing an Ansible Playbook automating IPAM.
While using the infoblox.nios_modules I noticed a weird behaviour. After creating a hostrecord with an IP-address x and a hostname, I executed the playbook again now with a different IP-address y and the same hostname. The secon hostrecord was placed in the IP-Adress y but also the first hostrecord was placed there. Also the extra attributes of the first hostrecord changed.

This was already described in #108 

I fixed the problem in the commit 19d50c43b4a6c507809ee0ff3346600494ddc891. I can not forsee if the general fix influences any other use case though.