### PR TITLE
Move handle_exception to WapiBase

### DIFF
--- a/plugins/module_utils/api.py
+++ b/plugins/module_utils/api.py
@@ -248,14 +248,16 @@ class WapiBase(object):
             else:
                 raise
 
-
-class WapiLookup(WapiBase):
-    ''' Implements WapiBase for lookup plugins '''
     def handle_exception(self, method_name, exc):
         if ('text' in exc.response):
             raise Exception(exc.response['text'])
         else:
             raise Exception(exc)
+
+
+class WapiLookup(WapiBase):
+    ''' Implements WapiBase for lookup plugins '''
+    pass
 
 
 class WapiInventory(WapiBase):


### PR DESCRIPTION
Everything inherits from WapiBase and everything should have a `handle_exception` method so move the method from just the WapiLookup class to the base so that everything at least has a general way to handle exceptions. 

Fixes #223  