### PR TITLE
 Exclude DNS View from filter criteria when configure_for_dns is false

### DIFF
--- a/changelogs/fragments/229-handle-host-rename-without-dns.yml
+++ b/changelogs/fragments/229-handle-host-rename-without-dns.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - nios_host_record - rename logic included DNS view in filter critera, even when DNS had been bypassed. Omits DNS view from filter critera when renaming a host object and DNS is bypassed. (https://github.com/infobloxopen/infoblox-ansible/issues/230)
+...

--- a/plugins/module_utils/api.py
+++ b/plugins/module_utils/api.py
@@ -679,7 +679,11 @@ class WapiModule(WapiBase):
 
             if old_name and new_name:
                 if (ib_obj_type == NIOS_HOST_RECORD):
-                    test_obj_filter = dict([('name', old_name), ('view', obj_filter['view'])])
+                    # to check only by old_name if dns bypassing is set
+                    if not obj_filter['configure_for_dns']:
+                        test_obj_filter = dict([('name', old_name)])
+                    else:
+                        test_obj_filter = dict([('name', old_name), ('view', obj_filter['view'])])
                 # if there are multiple records with same name and different ip
                 elif (ib_obj_type == NIOS_A_RECORD):
                     test_obj_filter = dict([('name', old_name), ('ipv4addr', obj_filter['ipv4addr'])])


### PR DESCRIPTION
This logic was already applied to scenarios that were not updating a name (lines 715-719). This commit simply applies the same logic to scenarios where names are being updated. Without this change, attempts to update the name of an existing host record that was created with `configure_for_dns: false` fail to find the existing record.