### PR TITLE
Pull 196: added support for use_logic_filter_rules and sanity fixes.

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -161,7 +161,7 @@ jobs:
              echo $ANSIBLE_NIOSSIM_CONTAINER
              ansible-test integration -v --color --retry-on-error --continue-on-error --diff --python ${{ matrix.python-version }} --docker --coverage
         env:
-           ANSIBLE_NIOSSIM_CONTAINER: quay.io/ansible/nios-test-container:3.0.0
+           ANSIBLE_NIOSSIM_CONTAINER: quay.io/ansible/nios-test-container:4.0.0
         working-directory: /home/runner/.ansible/collections/ansible_collections/infoblox/nios_modules/
 
         # ansible-test support producing code coverage date

--- a/plugins/doc_fragments/nios.py
+++ b/plugins/doc_fragments/nios.py
@@ -81,7 +81,7 @@ options:
             variable.
           - Until ansible 2.8 the default WAPI was 1.4
         type: str
-        default: '2.9'
+        default: '2.12.3'
       max_results:
         description:
           - Specifies the maximum number of objects to be returned,

--- a/plugins/lookup/nios_next_ip.py
+++ b/plugins/lookup/nios_next_ip.py
@@ -48,11 +48,13 @@ options:
 EXAMPLES = """
 - name: return next available IP address for network 192.168.10.0/24
   ansible.builtin.set_fact:
-    ipaddr: "{{ lookup('infoblox.nios_modules.nios_next_ip', '192.168.10.0/24', provider={'host': 'nios01', 'username': 'admin', 'password': 'password'}) }}"
+    ipaddr: "{{ lookup('infoblox.nios_modules.nios_next_ip', '192.168.10.0/24',
+    provider={'host': 'nios01', 'username': 'admin', 'password': 'password'}) }}"
 
 - name: return next available IP address for network 192.168.10.0/24 from DHCP range
   ansible.builtin.set_fact:
-    ipaddr: "{{ lookup('infoblox.nios_modules.nios_next_ip', '192.168.10.0/24', use_range=true, provider={'host': 'nios01', 'username': 'admin', 'password': 'password'}) }}"
+    ipaddr: "{{ lookup('infoblox.nios_modules.nios_next_ip', '192.168.10.0/24',
+    use_range=true, provider={'host': 'nios01', 'username': 'admin', 'password': 'password'}) }}"
 
 - name: return next available IP address for network 192.168.10.0/24 in a non-default network view
   ansible.builtin.set_fact:
@@ -64,14 +66,17 @@ EXAMPLES = """
     ipaddr: "{{ lookup('infoblox.nios_modules.nios_next_ip', '192.168.10.0/24', num=3,
                 provider={'host': 'nios01', 'username': 'admin', 'password': 'password'}) }}"
 
-- name: return the next 3 available IP addresses for network 192.168.10.0/24 excluding ip addresses - ['192.168.10.1', '192.168.10.2']
+- name: return the next 3 available IP addresses for network 192.168.10.0/24
+        excluding ip addresses - ['192.168.10.1', '192.168.10.2']
   ansible.builtin.set_fact:
-    ipaddr: "{{ lookup('infoblox.nios_modules.nios_next_ip', '192.168.10.0/24', num=3, exclude=['192.168.10.1', '192.168.10.2'],
+    ipaddr: "{{ lookup('infoblox.nios_modules.nios_next_ip', '192.168.10.0/24', num=3,
+                exclude=['192.168.10.1', '192.168.10.2'],
                 provider={'host': 'nios01', 'username': 'admin', 'password': 'password'}) }}"
 
 - name: return next available IP address for network fd30:f52:2:12::/64
   ansible.builtin.set_fact:
-    ipaddr: "{{ lookup('infoblox.nios_modules.nios_next_ip', 'fd30:f52:2:12::/64', provider={'host': 'nios01', 'username': 'admin', 'password': 'password'}) }}"
+    ipaddr: "{{ lookup('infoblox.nios_modules.nios_next_ip', 'fd30:f52:2:12::/64',
+    provider={'host': 'nios01', 'username': 'admin', 'password': 'password'}) }}"
 """
 
 RETURN = """

--- a/plugins/module_utils/api.py
+++ b/plugins/module_utils/api.py
@@ -92,7 +92,7 @@ NIOS_PROVIDER_SPEC = {
     'http_pool_connections': dict(type='int', default=10),
     'http_pool_maxsize': dict(type='int', default=10),
     'max_retries': dict(type='int', default=3, fallback=(env_fallback, ['INFOBLOX_MAX_RETRIES'])),
-    'wapi_version': dict(default='2.9', fallback=(env_fallback, ['INFOBLOX_WAPI_VERSION'])),
+    'wapi_version': dict(default='2.12.3', fallback=(env_fallback, ['INFOBLOX_WAPI_VERSION'])),
     'max_results': dict(type='int', default=1000, fallback=(env_fallback, ['INFOBLOX_MAX_RESULTS']))
 }
 

--- a/plugins/modules/nios_network.py
+++ b/plugins/modules/nios_network.py
@@ -111,6 +111,28 @@ options:
         description:
           - The name of the Nios member to be assigned to this network.
         type: str
+  use_logic_filter_rules:
+    description:
+      - If set to true it'll override the logic filter list applied at an upper level.
+    type: bool
+    default: false
+  logic_filter_rules:
+    description:
+      - Configures the logic filter rules to be applied to the network object.
+        This argument accepts a list of logic filter rules (see suboptions). When omitted
+        a default value of an empty list is used.
+    type: list
+    default: []
+    elements: dict
+    suboptions:
+      filter:
+        description:
+          - The name of the logic filter to apply to the network object.
+        type: str
+      type:
+        description:
+          - The type of the logic filter to apply to the network object.
+        type: str
   state:
     description:
       - Configures the intended state of the instance of the object on
@@ -179,6 +201,21 @@ EXAMPLES = '''
     options:
       - name: domain-name
         value: ansible.com
+    state: present
+    provider:
+      host: "{{ inventory_hostname_short }}"
+      username: admin
+      password: admin
+  connection: local
+
+- name: Set filters for a network ipv4
+  infoblox.nios_modules.nios_network:
+    network: 192.168.10.0/24
+    comment: this is a test comment
+    use_logic_filter_rules: true
+    logic_filter_rules:
+      - filter: PXE-UEFI
+        type: Option
     state: present
     provider:
       host: "{{ inventory_hostname_short }}"
@@ -329,7 +366,9 @@ def main():
         extattrs=dict(type='dict'),
         comment=dict(),
         container=dict(type='bool', ib_req=True),
-        members=dict(type='list', elements='dict', default=[])
+        members=dict(type='list', elements='dict', default=[]),
+        use_logic_filter_rules=dict(type='bool', default=False),
+        logic_filter_rules=dict(type='list', elements='dict', default=[])
     )
 
     argument_spec = dict(

--- a/tests/integration/targets/nios_network/tasks/nios_network_idempotence.yml
+++ b/tests/integration/targets/nios_network/tasks/nios_network_idempotence.yml
@@ -70,6 +70,53 @@
     provider: "{{ nios_provider }}"
   register: nios_ipv6_create1
 
+
+- name: configure a network ipv6 with filter option
+  nios_network:
+    network: fe80::/64
+    comment: this is a test comment
+    use_logic_filter_rules: true
+    state: present
+    provider: "{{ nios_provider }}"
+  register: nios_ipv6_update1
+
+- name: configure a network ipv4 with filter option
+  nios_network:
+    network: 192.168.11.0/24
+    comment: this is a test comment
+    use_logic_filter_rules: true
+    state: present
+    provider: "{{ nios_provider }}"
+  register: nios_ipv4_create3
+
+- name: update a network ipv4 with filter option
+  nios_network:
+    network: 192.168.11.0/24
+    comment: this is a test comment
+    use_logic_filter_rules: false
+    state: present
+    provider: "{{ nios_provider }}"
+  register: nios_ipv4_update3
+
+- name: Re-run with no changes
+  nios_network:
+    network: 192.168.11.0/24
+    comment: this is a test comment
+    use_logic_filter_rules: false
+    state: present
+    provider: "{{ nios_provider }}"
+  register: nios_ipv4_update4
+
+- name: remove an ipv4 network
+  nios_network:
+    network: 192.168.11.0/24
+    comment: this is a test comment
+    use_logic_filter_rules: false
+    state: absent
+    provider: "{{ nios_provider }}"
+  register: nios_ipv4_remove3
+
+
 - assert:
     that:
       - "nios_ipv4_create1.changed"
@@ -78,3 +125,10 @@
       - "not nios_ipv4_update2.changed"
       - "nios_ipv4_remove1.changed"
       - "not nios_ipv4_remove2.changed"
+      - "nios_ipv4_create3.changed"
+      - "nios_ipv4_update3.changed"
+      - "nios_ipv6_create1.changed"
+      - "nios_ipv6_update1.changed"
+      - "not nios_ipv4_update4.changed"
+      - "nios_ipv4_remove3.changed"
+

--- a/tests/integration/targets/nios_network/tasks/nios_network_idempotence.yml
+++ b/tests/integration/targets/nios_network/tasks/nios_network_idempotence.yml
@@ -131,4 +131,3 @@
       - "nios_ipv6_update1.changed"
       - "not nios_ipv4_update4.changed"
       - "nios_ipv4_remove3.changed"
-

--- a/tests/unit/plugins/modules/test_nios_network.py
+++ b/tests/unit/plugins/modules/test_nios_network.py
@@ -281,10 +281,11 @@ class TestNiosNetworkModule(TestNiosModule):
                               'comment': 'updated comment', 'extattrs': None, 'use_logic_filter_rules': True,
                               'logic_filter_rules': []}
 
+        ref = "network/ZG5zLm5ldHdvcmtfdmlldyQw:default/true"
         test_object = [
             {
                 "comment": "test comment",
-                "_ref": "network/ZG5zLm5ldHdvcmtfdmlldyQw:default/true",
+                "_ref": ref,
                 "network": "192.168.10.0/24",
                 "extattrs": {'options': {'name': 'test', 'value': 'ansible.com'}},
                 "use_logic_filter_rules": False,
@@ -304,3 +305,8 @@ class TestNiosNetworkModule(TestNiosModule):
         res = wapi.run('testobject', test_spec)
 
         self.assertTrue(res['changed'])
+        wapi.update_object.assert_called_once_with(ref, {'network': '192.168.10.0/24',
+                                                         'comment': 'updated comment',
+                                                         'use_logic_filter_rules': True,
+                                                         'logic_filter_rules': []}
+                                                   )

--- a/tests/unit/plugins/modules/test_nios_network.py
+++ b/tests/unit/plugins/modules/test_nios_network.py
@@ -30,12 +30,16 @@ class TestNiosNetworkModule(TestNiosModule):
 
     def setUp(self):
         super(TestNiosNetworkModule, self).setUp()
-        self.module = MagicMock(name='ansible_collections.infoblox.nios_modules.plugins.modules.nios_network.WapiModule')
+        self.module = MagicMock(
+            name='ansible_collections.infoblox.nios_modules.plugins.modules.nios_network.WapiModule'
+        )
         self.module.check_mode = False
         self.module.params = {'provider': None}
         self.mock_wapi = patch('ansible_collections.infoblox.nios_modules.plugins.modules.nios_network.WapiModule')
         self.exec_command = self.mock_wapi.start()
-        self.mock_wapi_run = patch('ansible_collections.infoblox.nios_modules.plugins.modules.nios_network.WapiModule.run')
+        self.mock_wapi_run = patch(
+            'ansible_collections.infoblox.nios_modules.plugins.modules.nios_network.WapiModule.run'
+        )
         self.mock_wapi_run.start()
         self.load_config = self.mock_wapi_run.start()
 
@@ -58,7 +62,8 @@ class TestNiosNetworkModule(TestNiosModule):
 
     def test_nios_network_ipv4_create(self):
         self.module.params = {'provider': None, 'state': 'present', 'network': '192.168.10.0/24',
-                              'comment': None, 'extattrs': None}
+                              'comment': None, 'extattrs': None, 'use_logic_filter_rules': False,
+                              'logic_filter_rules': []}
 
         test_object = None
         test_spec = {
@@ -246,3 +251,56 @@ class TestNiosNetworkModule(TestNiosModule):
 
         self.assertTrue(res['changed'])
         wapi.create_object.assert_called_once_with('testobject', {'ipv6networkcontainer': 'fe80::/64'})
+
+    def test_nios_network_ipv4_create_with_use_logic_filter_rules(self):
+        self.module.params = {'provider': None, 'state': 'present', 'network': '192.168.10.0/24',
+                              'comment': None, 'extattrs': None, 'use_logic_filter_rules': True,
+                              'logic_filter_rules': []}
+
+        test_object = None
+        test_spec = {
+            "network": {"ib_req": True},
+            "comment": {},
+            "extattrs": {},
+            "use_logic_filter_rules": {},
+            "logic_filter_rules": {}
+        }
+
+        wapi = self._get_wapi(test_object)
+        res = wapi.run('testobject', test_spec)
+
+        self.assertTrue(res['changed'])
+        wapi.create_object.assert_called_once_with('testobject', {'network': '192.168.10.0/24',
+                                                                  'use_logic_filter_rules': True,
+                                                                  'logic_filter_rules': []
+                                                                  }
+                                                   )
+
+    def test_nios_network_ipv4_update_with_use_logic_filter_rules(self):
+        self.module.params = {'provider': None, 'state': 'present', 'network': '192.168.10.0/24',
+                              'comment': 'updated comment', 'extattrs': None, 'use_logic_filter_rules': True,
+                              'logic_filter_rules': []}
+
+        test_object = [
+            {
+                "comment": "test comment",
+                "_ref": "network/ZG5zLm5ldHdvcmtfdmlldyQw:default/true",
+                "network": "192.168.10.0/24",
+                "extattrs": {'options': {'name': 'test', 'value': 'ansible.com'}},
+                "use_logic_filter_rules": False,
+                "logic_filter_rules": []
+            }
+        ]
+
+        test_spec = {
+            "network": {"ib_req": True},
+            "comment": {},
+            "extattrs": {},
+            "use_logic_filter_rules": {},
+            "logic_filter_rules": {}
+        }
+
+        wapi = self._get_wapi(test_object)
+        res = wapi.run('testobject', test_spec)
+
+        self.assertTrue(res['changed'])


### PR DESCRIPTION
[IMP] added support for use_logic_filter_rules
[UPD] added use_logic_filter_rules in example.
[IMP] added unit test cases for logic_filter_rules
- added use_logic_filter_rules and logic_filter_rules documentation.
- corrected sanity test failures.

**Sanity Test Result:**
```
Execute command: /root/.ansible/test/venv/sanity.yamllint/3.10/61ebfb13/bin/python /tmp/ansible-test-alczji_m-pip.py uninstall -y --disable-pip-version-check pip wheel
Run command: /root/.ansible/test/venv/sanity.yamllint/3.10/61ebfb13/bin/python /root/ansible/test/lib/ansible_test/_util/target/tools/yamlcheck.py
Run command with data: /root/.ansible/test/venv/sanity.yamllint/3.10/61ebfb13/bin/python /root/ansible/test/lib/ansible_test/_util/controller/sanity/yamllint/yamllinter.py
WARNING: There following sanity test virtual environments are out-of-date in the "default" container: sanity.ansible-doc-3.10, sanity.changelog-3.10, sanity.import-3.10, sanity.pep8-3.10, sanity.pylint-3.10, sanity.runtime-metadata-3.10, sanity.validate-modules-3.10, sanity.yamllint-3.10
WARNING: Reviewing previous 1 warning(s):
WARNING: There following sanity test virtual environments are out-of-date in the "default" container: sanity.ansible-doc-3.10, sanity.changelog-3.10, sanity.import-3.10, sanity.pep8-3.10, sanity.pylint-3.10, sanity.runtime-metadata-3.10, sanity.validate-modules-3.10, sanity.yamllint-3.10
Run command with stdout: docker exec -i ansible-test-controller-th3UaLyn sh -c 'tar cf - -C /root/ansible_collections/infoblox/nios_modules/tests --exclude .tmp output | gzip'
Run command with stdin: tar oxzf - -C /Users/jchhatbar/.ansible/collections/ansible_collections/infoblox/nios_modules/tests
Run command: docker stop --time 0 ansible-test-controller-th3UaLyn
Run command: docker rm ansible-test-controller-th3UaLyn
```

**Unit Test Result:**
```
- generated xml file: /Users/jchhatbar/.ansible/collections/ansible_collections/infoblox/nios_modules/tests/output/junit/python3.10-modules-units.xml -
============================== 88 passed in 3.80s ==============================

- generated xml file: /Users/jchhatbar/.ansible/collections/ansible_collections/infoblox/nios_modules/tests/output/junit/python3.10-module_utils-units.xml -
============================== 9 passed in 2.27s ===============================
```