### PR TITLE
- [NPA-113] Unable to remove DHCP options from DHCP Range using ansible.

### DIFF
--- a/plugins/module_utils/api.py
+++ b/plugins/module_utils/api.py
@@ -384,7 +384,7 @@ class WapiModule(WapiBase):
         if (ib_obj_type == NIOS_IPV4_NETWORK or ib_obj_type == NIOS_IPV6_NETWORK):
             proposed_object = convert_members_to_struct(proposed_object)
 
-        if ib_obj_type in {NIOS_IPV4_NETWORK_CONTAINER, NIOS_IPV6_NETWORK_CONTAINER, NIOS_IPV4_NETWORK, NIOS_IPV6_NETWORK}:
+        if ib_obj_type in {NIOS_IPV4_NETWORK_CONTAINER, NIOS_IPV6_NETWORK_CONTAINER, NIOS_IPV4_NETWORK, NIOS_IPV6_NETWORK, NIOS_RANGE}:
 
             # Iterate over each option and remove the 'num' key
             if current_object.get('options') or proposed_object.get('options'):

--- a/plugins/modules/nios_range.py
+++ b/plugins/modules/nios_range.py
@@ -44,6 +44,7 @@ options:
         of values (see suboptions).  When configuring suboptions at
         least one of C(name) or C(num) must be specified.
     type: list
+    default: []
     elements: dict
     suboptions:
       name:
@@ -375,7 +376,7 @@ def main():
         new_end_addr=dict(aliases=['new_end', 'new_last_addr', 'new_last'], type='str'),
         name=dict(type='str'),
         disable=dict(type='bool', default='false',),
-        options=dict(type='list', elements='dict', options=option_spec, transform=options),
+        options=dict(type='list', elements='dict', options=option_spec, transform=options, default=[]),
         member=dict(type='str'),
         failover_association=dict(type='str'),
         ms_server=dict(type='str'),


### PR DESCRIPTION
- Fixed [NPA-113] Unable to remove DHCP options from DHCP Range using ansible.