### PR TITLE
Update nios_inventory.py

### DIFF
--- a/plugins/inventory/nios_inventory.py
+++ b/plugins/inventory/nios_inventory.py
@@ -102,6 +102,7 @@ class InventoryModule(BaseInventoryPlugin):
             self.inventory.add_child(group_name, host_name)
 
             self.inventory.set_variable(host_name, 'view', host['view'])
+            self.inventory.set_variable(host_name, 'ipv4addrs', host['ipv4addrs'])
 
             for key, value in iteritems(flatten_extattrs(host['extattrs'])):
                 self.inventory.set_variable(host_name, key, value)


### PR DESCRIPTION
Set inventory variable for 'ipv4addrs'

Without this line plugin gets ipv4addrs list from wapi but doesn't compose host variable in inventory.