### PR TITLE
Fix for issue #278: bug in host state:present when run multiple time on same data for host with alias

### DIFF
--- a/plugins/module_utils/api.py
+++ b/plugins/module_utils/api.py
@@ -705,7 +705,7 @@ class WapiModule(WapiBase):
                     return False
 
                 for subitem in proposed_item:
-                    if current_item:
+                    if key == 'ipv4addrs' and current_item:
                         # Host IPv4addrs wont contain use_nextserver and nextserver
                         # If DHCP is false.
                         dhcp_flag = current_item[0].get('configure_for_dhcp', False)


### PR DESCRIPTION
.../ansible_collections/infoblox/nios_modules/plugins/module_utils/api.py\", line 710, in compare_objects\nAttributeError: 'str' object has no attribute 'get'

Fixed by ensuring code is only run for ipv4addr