### PR TITLE
Implement support for retrieving arbitrarily-large record sets with p…

### DIFF
--- a/changelogs/fragments/feature_paging.yml
+++ b/changelogs/fragments/feature_paging.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - infoblox-ansible - Add support for retrieving arbitrarily large amount of records using paging. (https://github.com/infobloxopen/infoblox-ansible/issues/293)

--- a/plugins/module_utils/api.py
+++ b/plugins/module_utils/api.py
@@ -100,7 +100,8 @@ NIOS_PROVIDER_SPEC = {
     'http_pool_maxsize': dict(type='int', default=10),
     'max_retries': dict(type='int', default=3, fallback=(env_fallback, ['INFOBLOX_MAX_RETRIES'])),
     'wapi_version': dict(default='2.12.3', fallback=(env_fallback, ['INFOBLOX_WAPI_VERSION'])),
-    'max_results': dict(type='int', default=1000, fallback=(env_fallback, ['INFOBLOX_MAX_RESULTS']))
+    'max_results': dict(type='int', default=1000, fallback=(env_fallback, ['INFOBLOX_MAX_RESULTS'])),
+    'paging': dict(type='bool', default=True, fallback=(env_fallback, ['INFOBLOX_PAGING']))
 }
 
 


### PR DESCRIPTION
…aging

By default, the infoblox-ansible module will retrieve at most 1000 results, and silently discard the remainder. This can often be surprising and not what users intend. Trying to work around this limitation by setting large result-set sizes can also be resource intensive on both client and server.

Our underpinning Python library natively supports the use of paging; it defaults to off, but is relatively trivial to wire up.

This commit wires up a 'paging' boolean option in the infoblox provider, and defaults setting it to 'true'.  It then passes this option to the underlying infoblox-client library.

https://github.com/infobloxopen/infoblox-ansible/issues/293