### PR TITLE
More DHCP options usable via `infoblox.nios_modules.nios_network`

### DIFF
--- a/plugins/modules/nios_network.py
+++ b/plugins/modules/nios_network.py
@@ -337,7 +337,7 @@ def check_vendor_specific_dhcp_option(module, ib_spec):
         if isinstance(module.params[key], list):
             for temp_dict in module.params[key]:
                 if 'num' in temp_dict:
-                    if temp_dict['num'] in (43, 124, 125, 67, 60):
+                    if temp_dict['num'] in (43, 124, 125, 67, 60, 1, 3, 42):
                         del temp_dict['use_option']
     return ib_spec
 


### PR DESCRIPTION
Related issue: https://github.com/infobloxopen/infoblox-ansible/issues/221
Similar commits: https://github.com/infobloxopen/infoblox-ansible/commit/4212a4197f8851759b851bfedaa191d6229896ba

According to the official Infoblox [WAPI documentation](https://ipam.illinois.edu/wapidoc/additional/structs.html#struct-dhcpoption) only special DHCP options have the `use_option` flag.

There is a method `check_vendor_specific_dhcp_options` that ensures DHCP options lose the `use_option` flag where required.

This adds the following DHCP option codes in order to be able to use them with the `nios_network` module:
* 1 Subnet-Mask
* 3 router
* 42 ntp-server