### PR TITLE
Correct CIDR doc type and harden argument validation

### DIFF
--- a/changelogs/fragments/315-nios-next-network-cidr.yml
+++ b/changelogs/fragments/315-nios-next-network-cidr.yml
@@ -1,0 +1,13 @@
+---
+breaking_changes:
+  - nios_next_network lookup - the C(cidr) argument is now required and must be an
+    integer. Previously, omitting C(cidr) silently defaulted to C(24); playbooks
+    that relied on this default now fail with C(AnsibleError - missing required
+    argument - cidr). Update such playbooks to pass C(cidr) explicitly.
+    (https://github.com/infobloxopen/infoblox-ansible/pull/315)
+bugfixes:
+  - nios_next_network lookup - accept C(cidr) as either an integer or a numeric
+    string and validate it consistently, while rejecting C(bool) and C(float)
+    values that previously passed through or were silently truncated (for
+    example C(25.7) became C(25)).
+    (https://github.com/infobloxopen/infoblox-ansible/pull/315)

--- a/plugins/lookup/nios_next_network.py
+++ b/plugins/lookup/nios_next_network.py
@@ -100,11 +100,9 @@ class LookupModule(LookupBase):
             raise AnsibleError('network argument is missing')
         except (ValueError, TypeError) as error:
             raise AnsibleError('network argument is invalid %s' % error)
-        try:
-            cidr = kwargs.get('cidr', 24)
-            # maybe using network.prefixlen+1 as default
-        except IndexError:
-            raise AnsibleError('missing CIDR argument in the form of xx')
+        cidr = kwargs.get('cidr')
+        if cidr is None:
+            raise AnsibleError('missing required argument: cidr')
         if isinstance(cidr, bool):
             raise AnsibleError('cidr must be an integer, got %r' % (cidr,))
         try:

--- a/plugins/lookup/nios_next_network.py
+++ b/plugins/lookup/nios_next_network.py
@@ -103,7 +103,9 @@ class LookupModule(LookupBase):
         cidr = kwargs.get('cidr')
         if cidr is None:
             raise AnsibleError('missing required argument: cidr')
-        if isinstance(cidr, bool):
+        # Reject bool and float explicitly: bool is a subclass of int, and
+        # int(25.7) would silently truncate to 25, masking a user error.
+        if isinstance(cidr, (bool, float)):
             raise AnsibleError('cidr must be an integer, got %r' % (cidr,))
         try:
             cidr = int(cidr)

--- a/plugins/lookup/nios_next_network.py
+++ b/plugins/lookup/nios_next_network.py
@@ -29,7 +29,7 @@ options:
         - The CIDR of the network to retrieve the next network from next available network within the
           specified container. Also, Requested CIDR must be specified and greater than the parent CIDR.
       required: True
-      type: str
+      type: int
     num:
       description: The number of network addresses to return from network-container.
       required: false
@@ -105,9 +105,10 @@ class LookupModule(LookupBase):
             # maybe using network.prefixlen+1 as default
         except IndexError:
             raise AnsibleError('missing CIDR argument in the form of xx')
-
-        if network.prefixlen >= cidr:
-            raise AnsibleError('cidr %s must be greater than parent network cidr %s' % (cidr, network.prefixlen))
+        try:
+            cidr = int(cidr)
+        except (TypeError, ValueError):
+            raise AnsibleError('cidr must be an integer, got %r' % (cidr,))
 
         container_type = None
         network_objects = None

--- a/plugins/lookup/nios_next_network.py
+++ b/plugins/lookup/nios_next_network.py
@@ -105,6 +105,8 @@ class LookupModule(LookupBase):
             # maybe using network.prefixlen+1 as default
         except IndexError:
             raise AnsibleError('missing CIDR argument in the form of xx')
+        if isinstance(cidr, bool):
+            raise AnsibleError('cidr must be an integer, got %r' % (cidr,))
         try:
             cidr = int(cidr)
         except (TypeError, ValueError):

--- a/plugins/lookup/nios_next_network.py
+++ b/plugins/lookup/nios_next_network.py
@@ -115,11 +115,11 @@ class LookupModule(LookupBase):
         # check for ip version 4 or 6 else die
         if network.version == 4:
             container_type = NIOS_IPV4_NETWORK_CONTAINER
-            if cidr not in range(1, 32):
+            if cidr not in range(1, 33):
                 raise AnsibleError('cidr %s must be in range 1 to 32' % cidr)
         elif network.version == 6:
             container_type = NIOS_IPV6_NETWORK_CONTAINER
-            if cidr not in range(1, 128):
+            if cidr not in range(1, 129):
                 raise AnsibleError('cidr %s must be in range 1 to 128' % cidr)
         else:
             raise AnsibleError('not a valid ipv4 or ipv6 network definition %s' % terms[0])

--- a/tests/unit/plugins/lookup/test_nios_next_network.py
+++ b/tests/unit/plugins/lookup/test_nios_next_network.py
@@ -1,0 +1,140 @@
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+# Make coding more python3-ish
+
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+
+import unittest
+
+from ansible.errors import AnsibleError
+from ansible_collections.infoblox.nios_modules.tests.unit.compat.mock import patch, MagicMock
+from ansible_collections.infoblox.nios_modules.plugins.lookup import nios_next_network
+
+
+class TestNiosNextNetworkLookup(unittest.TestCase):
+
+    def setUp(self):
+        self.lookup = nios_next_network.LookupModule()
+
+    def _run(self, terms, **kwargs):
+        return self.lookup.run(terms, **kwargs)
+
+    # ---- network argument validation -------------------------------------
+
+    def test_missing_network_raises(self):
+        with self.assertRaises(AnsibleError) as ctx:
+            self._run([], cidr=25)
+        self.assertIn('network argument is missing', str(ctx.exception))
+
+    def test_invalid_network_raises(self):
+        with self.assertRaises(AnsibleError) as ctx:
+            self._run(['not-a-network'], cidr=25)
+        self.assertIn('network argument is invalid', str(ctx.exception))
+
+    # ---- cidr argument validation ----------------------------------------
+
+    def test_missing_cidr_raises(self):
+        with self.assertRaises(AnsibleError) as ctx:
+            self._run(['192.168.10.0/24'])
+        self.assertIn('missing required argument: cidr', str(ctx.exception))
+
+    def test_bool_cidr_rejected(self):
+        with self.assertRaises(AnsibleError) as ctx:
+            self._run(['192.168.10.0/24'], cidr=True)
+        self.assertIn('cidr must be an integer', str(ctx.exception))
+
+    def test_float_cidr_rejected(self):
+        # int(25.7) would silently truncate to 25; ensure we reject instead.
+        with self.assertRaises(AnsibleError) as ctx:
+            self._run(['192.168.10.0/24'], cidr=25.7)
+        self.assertIn('cidr must be an integer', str(ctx.exception))
+
+    def test_non_numeric_string_cidr_rejected(self):
+        with self.assertRaises(AnsibleError) as ctx:
+            self._run(['192.168.10.0/24'], cidr='twenty-five')
+        self.assertIn('cidr must be an integer', str(ctx.exception))
+
+    def test_ipv4_cidr_out_of_range(self):
+        with self.assertRaises(AnsibleError) as ctx:
+            self._run(['192.168.10.0/24'], cidr=33)
+        self.assertIn('must be in range 1 to 32', str(ctx.exception))
+
+    def test_ipv6_cidr_out_of_range(self):
+        with self.assertRaises(AnsibleError) as ctx:
+            self._run(['2001:1:111:1::0/64'], cidr=129)
+        self.assertIn('must be in range 1 to 128', str(ctx.exception))
+
+    def test_cidr_not_greater_than_parent(self):
+        with self.assertRaises(AnsibleError) as ctx:
+            self._run(['192.168.10.0/24'], cidr=24)
+        self.assertIn('must be greater than parent network cidr', str(ctx.exception))
+
+    # ---- successful lookup paths -----------------------------------------
+
+    @patch.object(nios_next_network, 'WapiLookup')
+    def test_numeric_string_cidr_accepted(self, mock_wapi_cls):
+        wapi = MagicMock()
+        wapi.get_object.return_value = [{'_ref': 'ref1', 'network_view': 'default'}]
+        wapi.call_func.return_value = {'networks': ['192.168.10.0/25']}
+        mock_wapi_cls.return_value = wapi
+
+        result = self._run(['192.168.10.0/24'], cidr='25')
+
+        self.assertEqual(result, [['192.168.10.0/25']])
+        # cidr passed to WAPI must be a real int, not the original string.
+        _, called_kwargs = wapi.call_func.call_args
+        self.assertEqual(called_kwargs, {})
+        called_args = wapi.call_func.call_args[0]
+        self.assertEqual(called_args[2]['cidr'], 25)
+        self.assertIsInstance(called_args[2]['cidr'], int)
+
+    @patch.object(nios_next_network, 'WapiLookup')
+    def test_int_cidr_success(self, mock_wapi_cls):
+        wapi = MagicMock()
+        wapi.get_object.return_value = [{'_ref': 'ref1', 'network_view': 'default'}]
+        wapi.call_func.return_value = {'networks': ['192.168.10.0/25']}
+        mock_wapi_cls.return_value = wapi
+
+        result = self._run(['192.168.10.0/24'], cidr=25)
+
+        self.assertEqual(result, [['192.168.10.0/25']])
+
+    @patch.object(nios_next_network, 'WapiLookup')
+    def test_container_not_found_raises(self, mock_wapi_cls):
+        wapi = MagicMock()
+        wapi.get_object.return_value = None
+        mock_wapi_cls.return_value = wapi
+
+        with self.assertRaises(AnsibleError) as ctx:
+            self._run(['192.168.10.0/24'], cidr=25)
+        self.assertIn('unable to find network-container object', str(ctx.exception))
+
+    @patch.object(nios_next_network, 'WapiLookup')
+    def test_no_records_for_network_view(self, mock_wapi_cls):
+        wapi = MagicMock()
+        wapi.get_object.return_value = [{'_ref': 'ref1', 'network_view': 'default'}]
+        mock_wapi_cls.return_value = wapi
+
+        with self.assertRaises(AnsibleError) as ctx:
+            self._run(['192.168.10.0/24'], cidr=25, network_view='other')
+        self.assertIn('no records found', str(ctx.exception))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Corrects the cidr argument type in the nios_next_network lookup plugin docs (str → int), makes cidr required (removes silent default of 24), hardens validation to reject bool/float/non-numeric values, and fixes the IPv4/IPv6 CIDR upper-bound checks to include /32 and /128. Adds unit tests covering all validation paths.