### PR TITLE
fix(api.py): fix import statements deprecation warning

### DIFF
--- a/changelogs/316-api-py-fix-import-deprecation-warning
+++ b/changelogs/316-api-py-fix-import-deprecation-warning
@@ -1,0 +1,2 @@
+bugfixes:
+  - api.py - fixes deprecation warning when import the `to_native` and `to_text` functions by using the new import path

--- a/plugins/module_utils/api.py
+++ b/plugins/module_utils/api.py
@@ -33,8 +33,8 @@ import json
 import os
 import copy
 from functools import partial
-from ansible.module_utils._text import to_native
-from ansible.module_utils._text import to_text
+from ansible.module_utils.common.text.converters import to_native
+from ansible.module_utils.common.text.converters import to_text
 from ansible.module_utils.basic import env_fallback
 from ansible.module_utils.common.validation import check_type_dict
 from ast import literal_eval as safe_eval


### PR DESCRIPTION
fixes the warning related to `to_native` and `to_text` functions import

#313 