### PR TITLE
fix(nios_host_record): allow delete/update of IPAM-only hosts (blank …

### DIFF
--- a/changelogs/fragments/300-nios_host_record-ipam-only-absent.yml
+++ b/changelogs/fragments/300-nios_host_record-ipam-only-absent.yml
@@ -1,0 +1,5 @@
+bugfixes:
+  - nios_host_record - fix ``state=absent`` silently no-op'ing on IPAM-only
+    host records (``configure_for_dns=false``), which NIOS stores with
+    ``view=" "`` rather than ``view="default"``
+    (https://github.com/infobloxopen/infoblox-ansible/issues/300).

--- a/plugins/module_utils/api.py
+++ b/plugins/module_utils/api.py
@@ -358,12 +358,31 @@ class WapiModule(WapiBase):
         # uses view='default' and returns 0 results, so we silently no-op and
         # leave the record on the grid. Retry the search without the view
         # filter to find IPAM-only hosts before declaring the object absent.
+        #
+        # To avoid acting on host records that live in unrelated DNS views,
+        # restrict the retry results to IPAM-only host records (view is blank
+        # or whitespace). If the retry still returns multiple eligible
+        # matches, fail with a clear error rather than picking one arbitrarily.
         if (ib_obj_type == NIOS_HOST_RECORD and not ib_obj_ref
                 and obj_filter.get('view') == 'default'):
             retry_filter = dict(obj_filter)
             retry_filter.pop('view', None)
-            ib_obj_ref, update, new_name = self.get_object_ref(
+            retry_obj_ref, retry_update, retry_new_name = self.get_object_ref(
                 self.module, ib_obj_type, retry_filter, ib_spec)
+            if retry_obj_ref:
+                ipam_only = [
+                    rec for rec in retry_obj_ref
+                    if isinstance(rec, dict)
+                    and isinstance(rec.get('view'), str)
+                    and not rec.get('view').strip()
+                ]
+                if len(ipam_only) > 1:
+                    self.module.fail_json(
+                        msg=("multiple IPAM-only host records named '%s' were found; "
+                             "specify 'view' or 'ipv4addrs' to disambiguate"
+                             % obj_filter.get('name')))
+                if ipam_only:
+                    ib_obj_ref, update, new_name = ipam_only, retry_update, retry_new_name
 
         # When a range update is defined, check for a range that matches the target range definition as well
         # to allows for idempotence
@@ -885,6 +904,25 @@ class WapiModule(WapiBase):
                     test_obj_filter = dict([('name', old_name)])
                 # get the object reference
                 ib_obj = self.get_object(ib_obj_type, test_obj_filter, return_fields=return_fields)
+                # Issue #300: when the host-record lookup above fell back to a
+                # name-only search because the view was blank/whitespace (or
+                # absent entirely on the IPAM-only retry path), restrict
+                # matches to IPAM-only records so we never rename a record
+                # that lives in an unrelated DNS view.
+                if ib_obj_type == NIOS_HOST_RECORD and ib_obj:
+                    _view = obj_filter.get('view')
+                    if _view is None or (isinstance(_view, str) and not _view.strip()):
+                        ipam_only = [
+                            rec for rec in ib_obj
+                            if isinstance(rec, dict)
+                            and isinstance(rec.get('view'), str)
+                            and not rec.get('view').strip()
+                        ]
+                        if len(ipam_only) > 1:
+                            self.module.fail_json(
+                                msg=("multiple IPAM-only host records named '%s' were found; "
+                                     "specify 'ipv4addrs' to disambiguate" % old_name))
+                        ib_obj = ipam_only or None
                 if ib_obj:
                     obj_filter['name'] = new_name
                 elif old_ipv4addr_exists and (len(ib_obj) == 0):
@@ -975,6 +1013,28 @@ class WapiModule(WapiBase):
                 return_fields.extend(ipv6addrs_return)
 
             ib_obj = self.get_object(ib_obj_type, test_obj_filter.copy(), return_fields=return_fields)
+
+            # Issue #300: when the host-record lookup falls back to name-only
+            # search because the view was blank/whitespace (or absent entirely
+            # on the IPAM-only retry path), the result may include records
+            # from unrelated DNS views. Restrict to IPAM-only host records
+            # (view is blank/whitespace) so we never act on the wrong record.
+            # Fail if the disambiguation is impossible.
+            if ib_obj_type == NIOS_HOST_RECORD and ib_obj:
+                _filter_view = obj_filter.get('view')
+                if _filter_view is None or (isinstance(_filter_view, str) and not _filter_view.strip()):
+                    ipam_only = [
+                        rec for rec in ib_obj
+                        if isinstance(rec, dict)
+                        and isinstance(rec.get('view'), str)
+                        and not rec.get('view').strip()
+                    ]
+                    if len(ipam_only) > 1:
+                        self.module.fail_json(
+                            msg=("multiple IPAM-only host records named '%s' were found; "
+                                 "specify 'ipv4addrs' to disambiguate"
+                                 % obj_filter.get('name')))
+                    ib_obj = ipam_only or None
 
             # prevents creation of a new A record with 'new_ipv4addr' when A record with a particular 'old_ipv4addr' is not found
             if old_ipv4addr_exists and (ib_obj is None or len(ib_obj) == 0):

--- a/plugins/module_utils/api.py
+++ b/plugins/module_utils/api.py
@@ -353,6 +353,18 @@ class WapiModule(WapiBase):
         # get object reference
         ib_obj_ref, update, new_name = self.get_object_ref(self.module, ib_obj_type, obj_filter, ib_spec)
 
+        # Issue #300: IPAM-only host records carry view=' ' in WAPI. If the user
+        # calls state=absent (or update) without specifying a view, our search
+        # uses view='default' and returns 0 results, so we silently no-op and
+        # leave the record on the grid. Retry the search without the view
+        # filter to find IPAM-only hosts before declaring the object absent.
+        if (ib_obj_type == NIOS_HOST_RECORD and not ib_obj_ref
+                and obj_filter.get('view') == 'default'):
+            retry_filter = dict(obj_filter)
+            retry_filter.pop('view', None)
+            ib_obj_ref, update, new_name = self.get_object_ref(
+                self.module, ib_obj_type, retry_filter, ib_spec)
+
         # When a range update is defined, check for a range that matches the target range definition as well
         # to allows for idempotence
         if ib_obj_type == NIOS_RANGE and len(ib_obj_ref) == 0 and \
@@ -376,10 +388,15 @@ class WapiModule(WapiBase):
                 if transformed_value is not None:
                     proposed_object[key] = transformed_value
 
-        # If configure_by_dns is set to False and view is 'default', then delete the default dns
-        if not proposed_object.get('configure_for_dns') and proposed_object.get('view') == 'default' \
-                and ib_obj_type == NIOS_HOST_RECORD:
-            del proposed_object['view']
+        # Issue #300: IPAM-only (non-DNS) host records carry view=' ' in WAPI.
+        # Drop `view` from proposed_object when:
+        #   - DNS is bypassed and view defaults to 'default' (legacy behavior), OR
+        #   - the view value is blank/whitespace (matches the IPAM-only marker).
+        if ib_obj_type == NIOS_HOST_RECORD:
+            view_val = proposed_object.get('view')
+            if (not proposed_object.get('configure_for_dns') and view_val == 'default') \
+                    or (isinstance(view_val, str) and not view_val.strip()):
+                proposed_object.pop('view', None)
         if ib_obj_ref:
             if len(ib_obj_ref) > 1:
                 for each in ib_obj_ref:
@@ -839,11 +856,15 @@ class WapiModule(WapiBase):
 
             if old_name and new_name:
                 if (ib_obj_type == NIOS_HOST_RECORD):
-                    # to check only by old_name if dns bypassing is set
-                    if not obj_filter['configure_for_dns']:
+                    # to check only by old_name if dns bypassing is set, or if the
+                    # provided view is blank/whitespace (issue #300: IPAM-only host
+                    # records have view=' ', sending that to WAPI yields a 404).
+                    _view = obj_filter.get('view')
+                    if not obj_filter['configure_for_dns'] \
+                            or not (isinstance(_view, str) and _view.strip()):
                         test_obj_filter = dict([('name', old_name)])
                     else:
-                        test_obj_filter = dict([('name', old_name), ('view', obj_filter['view'])])
+                        test_obj_filter = dict([('name', old_name), ('view', _view)])
                 # if there are multiple records with the same name and different ip
                 elif (ib_obj_type == NIOS_A_RECORD):
                     test_obj_filter = dict([('name', old_name), ('ipv4addr', obj_filter['ipv4addr'])])
@@ -876,11 +897,15 @@ class WapiModule(WapiBase):
             if (ib_obj_type == NIOS_HOST_RECORD):
                 # to fix the sanity issue
                 name = obj_filter['name']
-                # to check only by name if dns bypassing is set
-                if not obj_filter['configure_for_dns']:
+                # to check only by name if dns bypassing is set, or if the provided
+                # view is blank/whitespace (issue #300: IPAM-only host records have
+                # view=' ', sending that to WAPI yields a 404).
+                _view = obj_filter.get('view')
+                if not obj_filter['configure_for_dns'] \
+                        or not (isinstance(_view, str) and _view.strip()):
                     test_obj_filter = dict([('name', name)])
                 else:
-                    test_obj_filter = dict([('name', name), ('view', obj_filter['view'])])
+                    test_obj_filter = dict([('name', name), ('view', _view)])
             elif (ib_obj_type == NIOS_IPV4_FIXED_ADDRESS and 'mac' in obj_filter):
                 test_obj_filter = dict([['mac', obj_filter['mac']]])
             elif (ib_obj_type == NIOS_IPV6_FIXED_ADDRESS and 'duid' in obj_filter):

--- a/plugins/module_utils/api.py
+++ b/plugins/module_utils/api.py
@@ -373,8 +373,8 @@ class WapiModule(WapiBase):
                 ipam_only = [
                     rec for rec in retry_obj_ref
                     if isinstance(rec, dict)
-                    and isinstance(rec.get('view'), str)
-                    and not rec.get('view').strip()
+                    and ((isinstance(rec.get('view'), str) and not rec.get('view').strip())
+                         or rec.get('configure_for_dns') is False)
                 ]
                 if len(ipam_only) > 1:
                     self.module.fail_json(
@@ -905,18 +905,21 @@ class WapiModule(WapiBase):
                 # get the object reference
                 ib_obj = self.get_object(ib_obj_type, test_obj_filter, return_fields=return_fields)
                 # Issue #300: when the host-record lookup above fell back to a
-                # name-only search because the view was blank/whitespace (or
-                # absent entirely on the IPAM-only retry path), restrict
-                # matches to IPAM-only records so we never rename a record
-                # that lives in an unrelated DNS view.
+                # name-only search (because the view was blank/whitespace,
+                # absent on the IPAM-only retry path, or configure_for_dns is
+                # False), restrict matches to IPAM-only records so we never
+                # rename a record that lives in an unrelated DNS view.
                 if ib_obj_type == NIOS_HOST_RECORD and ib_obj:
                     _view = obj_filter.get('view')
-                    if _view is None or (isinstance(_view, str) and not _view.strip()):
+                    _dns = obj_filter.get('configure_for_dns')
+                    if (_view is None
+                            or (isinstance(_view, str) and not _view.strip())
+                            or _dns is False):
                         ipam_only = [
                             rec for rec in ib_obj
                             if isinstance(rec, dict)
-                            and isinstance(rec.get('view'), str)
-                            and not rec.get('view').strip()
+                            and ((isinstance(rec.get('view'), str) and not rec.get('view').strip())
+                                 or rec.get('configure_for_dns') is False)
                         ]
                         if len(ipam_only) > 1:
                             self.module.fail_json(
@@ -1015,19 +1018,23 @@ class WapiModule(WapiBase):
             ib_obj = self.get_object(ib_obj_type, test_obj_filter.copy(), return_fields=return_fields)
 
             # Issue #300: when the host-record lookup falls back to name-only
-            # search because the view was blank/whitespace (or absent entirely
-            # on the IPAM-only retry path), the result may include records
-            # from unrelated DNS views. Restrict to IPAM-only host records
-            # (view is blank/whitespace) so we never act on the wrong record.
-            # Fail if the disambiguation is impossible.
+            # search (because the view was blank/whitespace, absent on the
+            # IPAM-only retry path, or because configure_for_dns is False),
+            # the result may include records from unrelated DNS views.
+            # Restrict to IPAM-only host records (view is blank/whitespace
+            # and/or configure_for_dns is False) so we never act on the
+            # wrong record. Fail if the disambiguation is impossible.
             if ib_obj_type == NIOS_HOST_RECORD and ib_obj:
                 _filter_view = obj_filter.get('view')
-                if _filter_view is None or (isinstance(_filter_view, str) and not _filter_view.strip()):
+                _filter_dns = obj_filter.get('configure_for_dns')
+                if (_filter_view is None
+                        or (isinstance(_filter_view, str) and not _filter_view.strip())
+                        or _filter_dns is False):
                     ipam_only = [
                         rec for rec in ib_obj
                         if isinstance(rec, dict)
-                        and isinstance(rec.get('view'), str)
-                        and not rec.get('view').strip()
+                        and ((isinstance(rec.get('view'), str) and not rec.get('view').strip())
+                             or rec.get('configure_for_dns') is False)
                     ]
                     if len(ipam_only) > 1:
                         self.module.fail_json(

--- a/plugins/module_utils/api.py
+++ b/plugins/module_utils/api.py
@@ -379,7 +379,7 @@ class WapiModule(WapiBase):
                 if len(ipam_only) > 1:
                     self.module.fail_json(
                         msg=("multiple IPAM-only host records named '%s' were found; "
-                             "specify 'view' or 'ipv4addrs' to disambiguate"
+                             "specify 'ipv4addrs' to disambiguate"
                              % obj_filter.get('name')))
                 if ipam_only:
                     ib_obj_ref, update, new_name = ipam_only, retry_update, retry_new_name

--- a/plugins/module_utils/api.py
+++ b/plugins/module_utils/api.py
@@ -378,8 +378,8 @@ class WapiModule(WapiBase):
                 ]
                 if len(ipam_only) > 1:
                     self.module.fail_json(
-                        msg=("multiple IPAM-only host records named '%s' were found; "
-                             "specify 'ipv4addrs' to disambiguate"
+                        msg=("multiple IPAM-only host records named '%s' were found "
+                             "and could not be disambiguated"
                              % obj_filter.get('name')))
                 if ipam_only:
                     ib_obj_ref, update, new_name = ipam_only, retry_update, retry_new_name
@@ -923,8 +923,8 @@ class WapiModule(WapiBase):
                         ]
                         if len(ipam_only) > 1:
                             self.module.fail_json(
-                                msg=("multiple IPAM-only host records named '%s' were found; "
-                                     "specify 'ipv4addrs' to disambiguate" % old_name))
+                                msg=("multiple IPAM-only host records named '%s' were found "
+                                     "and could not be disambiguated" % old_name))
                         ib_obj = ipam_only or None
                 if ib_obj:
                     obj_filter['name'] = new_name
@@ -1038,8 +1038,8 @@ class WapiModule(WapiBase):
                     ]
                     if len(ipam_only) > 1:
                         self.module.fail_json(
-                            msg=("multiple IPAM-only host records named '%s' were found; "
-                                 "specify 'ipv4addrs' to disambiguate"
+                            msg=("multiple IPAM-only host records named '%s' were found "
+                                 "and could not be disambiguated"
                                  % obj_filter.get('name')))
                     ib_obj = ipam_only or None
 

--- a/tests/unit/plugins/module_utils/test_api.py
+++ b/tests/unit/plugins/module_utils/test_api.py
@@ -258,3 +258,129 @@ class TestNiosApi(unittest.TestCase):
 
         self.assertTrue(res['changed'])
         wapi.update_object.assert_called_once_with(ref, kwargs)
+
+    # ------------------------------------------------------------------
+    # Issue #300: IPAM-only (non-DNS) host records carry view=' ' in WAPI.
+    # The tests below cover the new view-handling paths in WapiModule.run()
+    # and WapiModule.get_object_ref().
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _host_record_spec():
+        return {
+            "name": {"ib_req": True},
+            "view": {"ib_req": True},
+            "configure_for_dns": {"ib_req": True},
+            "ipv4addrs": {},
+            "comment": {},
+            "extattrs": {},
+        }
+
+    def test_host_record_blank_view_omits_view_from_lookup(self):
+        # User explicitly passes view=' ' (an IPAM-only host record's WAPI
+        # marker). The lookup must be performed without 'view' in the
+        # search filter so WAPI doesn't return 'View not found'.
+        ref = "record:host/ZG5zLmhvc3QkLl9kZWZhdWx0Lmlwc28x:ipso-host/%20"
+        ipam_only = {
+            "_ref": ref, "name": "ipso-host", "view": " ",
+            "configure_for_dns": False, "ipv4addrs": [], "extattrs": {},
+        }
+        self.module.params = {
+            'provider': None, 'state': 'absent', 'name': 'ipso-host',
+            'view': ' ', 'configure_for_dns': False,
+            'ipv4addrs': None, 'comment': None, 'extattrs': None,
+        }
+        wapi = self._get_wapi([ipam_only])
+        res = wapi.run(api.NIOS_HOST_RECORD, self._host_record_spec())
+
+        self.assertTrue(res['changed'])
+        wapi.delete_object.assert_called_once_with(ref)
+        # The lookup filter passed to get_object must not contain 'view'
+        # when the user-supplied view is blank/whitespace.
+        called_filter = wapi.get_object.call_args[0][1]
+        self.assertNotIn('view', called_filter)
+
+    def test_host_record_default_view_retry_finds_ipam_only(self):
+        # User runs state=absent without specifying view, so view defaults
+        # to 'default'. The first lookup (view='default') returns nothing;
+        # the retry without the view filter must find the IPAM-only record
+        # (view=' ') and delete it.
+        ref = "record:host/ZG5zLmhvc3QkLl9kZWZhdWx0Lmlwc28x:ipso-host/%20"
+        ipam_only = {
+            "_ref": ref, "name": "ipso-host", "view": " ",
+            "configure_for_dns": False, "ipv4addrs": [], "extattrs": {},
+        }
+        responses = [[], [ipam_only]]
+        self.module.params = {
+            'provider': None, 'state': 'absent', 'name': 'ipso-host',
+            'view': 'default', 'configure_for_dns': True,
+            'ipv4addrs': None, 'comment': None, 'extattrs': None,
+        }
+        wapi = api.WapiModule(self.module)
+        wapi.get_object = Mock(side_effect=responses)
+        wapi.create_object = Mock()
+        wapi.update_object = Mock()
+        wapi.delete_object = Mock()
+
+        res = wapi.run(api.NIOS_HOST_RECORD, self._host_record_spec())
+
+        self.assertTrue(res['changed'])
+        wapi.delete_object.assert_called_once_with(ref)
+
+    def test_host_record_default_view_retry_ignores_other_dns_views(self):
+        # The retry path must NOT match records that live in a non-default
+        # DNS view (view='external'); those are not IPAM-only records and
+        # acting on them would be wrong. The module should treat the
+        # absent operation as a no-op (changed=False).
+        external_view_record = {
+            "_ref": "record:host/abc:ipso-host/external",
+            "name": "ipso-host", "view": "external",
+            "configure_for_dns": True, "ipv4addrs": [], "extattrs": {},
+        }
+        responses = [[], [external_view_record]]
+        self.module.params = {
+            'provider': None, 'state': 'absent', 'name': 'ipso-host',
+            'view': 'default', 'configure_for_dns': True,
+            'ipv4addrs': None, 'comment': None, 'extattrs': None,
+        }
+        wapi = api.WapiModule(self.module)
+        wapi.get_object = Mock(side_effect=responses)
+        wapi.create_object = Mock()
+        wapi.update_object = Mock()
+        wapi.delete_object = Mock()
+
+        res = wapi.run(api.NIOS_HOST_RECORD, self._host_record_spec())
+
+        self.assertFalse(res['changed'])
+        wapi.delete_object.assert_not_called()
+
+    def test_host_record_blank_view_multiple_matches_fails(self):
+        # If the IPAM-only name-only fallback search returns more than one
+        # eligible (blank-view) record, the module must fail rather than
+        # silently picking one.
+        match_a = {
+            "_ref": "record:host/a:ipso-host/%20",
+            "name": "ipso-host", "view": " ",
+            "configure_for_dns": False, "ipv4addrs": [], "extattrs": {},
+        }
+        match_b = {
+            "_ref": "record:host/b:ipso-host/%20",
+            "name": "ipso-host", "view": " ",
+            "configure_for_dns": False, "ipv4addrs": [], "extattrs": {},
+        }
+        self.module.params = {
+            'provider': None, 'state': 'absent', 'name': 'ipso-host',
+            'view': ' ', 'configure_for_dns': False,
+            'ipv4addrs': None, 'comment': None, 'extattrs': None,
+        }
+        wapi = self._get_wapi([match_a, match_b])
+        self.module.fail_json.reset_mock()
+        self.module.fail_json.side_effect = SystemExit(1)
+
+        with self.assertRaises(SystemExit):
+            wapi.run(api.NIOS_HOST_RECORD, self._host_record_spec())
+
+        self.module.fail_json.assert_called_once()
+        msg_kwargs = self.module.fail_json.call_args[1]
+        self.assertIn('multiple IPAM-only host records', msg_kwargs.get('msg', ''))
+        wapi.delete_object.assert_not_called()

--- a/tests/unit/plugins/module_utils/test_api.py
+++ b/tests/unit/plugins/module_utils/test_api.py
@@ -384,3 +384,31 @@ class TestNiosApi(unittest.TestCase):
         msg_kwargs = self.module.fail_json.call_args[1]
         self.assertIn('multiple IPAM-only host records', msg_kwargs.get('msg', ''))
         wapi.delete_object.assert_not_called()
+
+    def test_host_record_configure_for_dns_false_filters_out_dns_records(self):
+        # Legacy fallback: when configure_for_dns=False, the lookup falls
+        # back to name-only even if view='default'. If a DNS-enabled host
+        # with the same name exists in some view, name-only search returns
+        # both. The module must filter out the DNS-enabled record and act
+        # only on the IPAM-only one (configure_for_dns=False).
+        ipam_only_ref = "record:host/a:ipso-host/%20"
+        dns_record = {
+            "_ref": "record:host/b:ipso-host/default",
+            "name": "ipso-host", "view": "default",
+            "configure_for_dns": True, "ipv4addrs": [], "extattrs": {},
+        }
+        ipam_only = {
+            "_ref": ipam_only_ref, "name": "ipso-host", "view": " ",
+            "configure_for_dns": False, "ipv4addrs": [], "extattrs": {},
+        }
+        self.module.params = {
+            'provider': None, 'state': 'absent', 'name': 'ipso-host',
+            'view': 'default', 'configure_for_dns': False,
+            'ipv4addrs': None, 'comment': None, 'extattrs': None,
+        }
+        wapi = self._get_wapi([dns_record, ipam_only])
+
+        res = wapi.run(api.NIOS_HOST_RECORD, self._host_record_spec())
+
+        self.assertTrue(res['changed'])
+        wapi.delete_object.assert_called_once_with(ipam_only_ref)


### PR DESCRIPTION
…view)

Issue #300

IPAM-only (non-DNS) host records carry view=' ' (single space) in WAPI. The module's get_object_ref() always included 'view' in the host-record search filter, producing two distinct failure modes:

  - view: '' or view: ' '  -> WAPI 404 'AdmConDataNotFoundError: View  not found' surfaced as a fatal traceback.
  - view omitted (defaults to 'default') -> search returned 0 records, module silently treated the host as 'already absent' and reported success without deleting anything.

Changes in plugins/module_utils/api.py:

* get_object_ref() (both NIOS_HOST_RECORD branches): drop 'view' from the search filter when the value is None or blank/whitespace, in addition to the existing 'configure_for_dns is False' case.
* run(): when a host-record search yields no results and the caller used the default view ('default'), retry the lookup without the view filter so IPAM-only records (view=' ') are found and acted upon.
* run(): also drop 'view' from proposed_object when it is blank, so the payload sent to WAPI never carries an empty/space view.

Verified with Ansible-issues/issue_300.yml against NIOS 2.12.3: all three scenarios (view='', view=' ', view defaulted) now create and delete IPAM-only host records cleanly.