### PR TITLE
Fix #305: return resolved object from nios_* modules after create/update

### DIFF
--- a/changelogs/fragments/305-return-resolved-object-after-create-update.yaml
+++ b/changelogs/fragments/305-return-resolved-object-after-create-update.yaml
@@ -1,0 +1,14 @@
+---
+minor_changes:
+  - |
+    nios_* modules - After a successful create or update (``state: present``,
+    ``changed: true``), modules now return the canonical NIOS object under
+    ``result.object``. This makes lookup-allocated values (for example, the IP
+    chosen by ``func: nios_next_ip`` or the network chosen by
+    ``func: nios_next_network``) accessible to downstream tasks
+    (https://github.com/infobloxopen/infoblox-ansible/issues/305,
+    https://github.com/infobloxopen/infoblox-ansible/issues/304).
+bugfixes:
+  - |
+    nios_* modules - Update path no longer calls ``update_object`` in check
+    mode; the existing ref is preserved instead.

--- a/plugins/module_utils/api.py
+++ b/plugins/module_utils/api.py
@@ -87,6 +87,15 @@ NIOS_EXTENSIBLE_ATTRIBUTE = 'extensibleattributedef'
 NIOS_VLAN = 'vlan'
 NIOS_ADMINUSER = 'adminuser'
 
+# Object types that intentionally do NOT participate in the post-write
+# re-fetch performed at the end of WapiModule.run() (issue #305).
+# NIOS_MEMBER's create_token path already returns its payload under
+# result['api_results'] and there is no canonical 'member' object to re-read
+# in that flow.
+NIOS_RETURN_OBJECT_EXCLUDE = frozenset({
+    NIOS_MEMBER,
+})
+
 NIOS_PROVIDER_SPEC = {
     'host': dict(fallback=(env_fallback, ['INFOBLOX_HOST'])),
     'username': dict(fallback=(env_fallback, ['INFOBLOX_USERNAME'])),
@@ -572,7 +581,7 @@ class WapiModule(WapiBase):
         if state == 'present':
             if ref is None:
                 if not self.module.check_mode:
-                    self.create_object(ib_obj_type, proposed_object)
+                    res = self.create_object(ib_obj_type, proposed_object)
                 result['changed'] = True
             # Check if NIOS_MEMBER and the flag to call function create_token is set
             elif (ib_obj_type == NIOS_MEMBER) and (proposed_object.get("create_token") is True):
@@ -608,7 +617,7 @@ class WapiModule(WapiBase):
                     # popping 'zone_format' key as update of 'zone_format' is not supported with respect to zone_auth
                     proposed_object = self.on_update(proposed_object, ib_spec)
                     del proposed_object['zone_format']
-                    self.update_object(ref, proposed_object)
+                    res = self.update_object(ref, proposed_object)
                     result['changed'] = True
                 elif 'network_view' in proposed_object and (ib_obj_type not in (NIOS_IPV4_FIXED_ADDRESS, NIOS_IPV6_FIXED_ADDRESS, NIOS_RANGE)):
                     proposed_object.pop('network_view')
@@ -652,6 +661,42 @@ class WapiModule(WapiBase):
                 elif not self.module.check_mode:
                     self.delete_object(ref)
                     result['changed'] = True
+
+        # ------------------------------------------------------------------
+        # Fix for issue #305 (generalized):
+        # After a successful present-state write, re-fetch the canonical
+        # object so the caller's `register:` variable exposes WAPI-resolved
+        # values (notably IPs produced by func:nextavailableip and networks
+        # produced by func:nextavailablenetwork). The fields requested are
+        # derived from the calling module's ib_spec so this works for every
+        # WAPI object type without a per-type table that would need to be
+        # maintained as the schema evolves.
+        # ------------------------------------------------------------------
+        if (state == 'present'
+                and result.get('changed')
+                and not self.module.check_mode
+                and ib_obj_type not in NIOS_RETURN_OBJECT_EXCLUDE):
+            target_ref = res if res else ref
+            if target_ref:
+                return_fields = sorted({
+                    k for k in ib_spec.keys()
+                    if not k.startswith('_') and k not in ('provider', 'state')
+                })
+                try:
+                    fetched = self.connector.get_object(
+                        obj_type=str(target_ref),
+                        return_fields=return_fields or None,
+                    )
+                    if fetched:
+                        # get_object on a _ref returns a dict; on a search it
+                        # returns a list. Handle both defensively.
+                        result['object'] = (
+                            fetched[0] if isinstance(fetched, list) else fetched
+                        )
+                except Exception:
+                    # Never fail the task because the post-fetch failed; the
+                    # create/update itself already succeeded server-side.
+                    pass
 
         return result
 

--- a/plugins/module_utils/api.py
+++ b/plugins/module_utils/api.py
@@ -617,7 +617,10 @@ class WapiModule(WapiBase):
                     # popping 'zone_format' key as update of 'zone_format' is not supported with respect to zone_auth
                     proposed_object = self.on_update(proposed_object, ib_spec)
                     del proposed_object['zone_format']
-                    res = self.update_object(ref, proposed_object)
+                    if not self.module.check_mode:
+                        res = self.update_object(ref, proposed_object)
+                    else:
+                        res = ref
                     result['changed'] = True
                 elif 'network_view' in proposed_object and (ib_obj_type not in (NIOS_IPV4_FIXED_ADDRESS, NIOS_IPV6_FIXED_ADDRESS, NIOS_RANGE)):
                     proposed_object.pop('network_view')
@@ -682,21 +685,34 @@ class WapiModule(WapiBase):
                     k for k in ib_spec.keys()
                     if not k.startswith('_') and k not in ('provider', 'state')
                 })
+                fetched = None
                 try:
                     fetched = self.connector.get_object(
                         obj_type=str(target_ref),
                         return_fields=return_fields or None,
                     )
-                    if fetched:
-                        # get_object on a _ref returns a dict; on a search it
-                        # returns a list. Handle both defensively.
-                        result['object'] = (
-                            fetched[0] if isinstance(fetched, list) else fetched
-                        )
                 except Exception:
-                    # Never fail the task because the post-fetch failed; the
-                    # create/update itself already succeeded server-side.
-                    pass
+                    # Some modules include helper/read-only ib_spec keys that
+                    # are not valid WAPI return fields (e.g., nios_zone's
+                    # restart_if_needed, nios_network's template,
+                    # nios_range's new_start_addr/new_end_addr). Retry the
+                    # fetch without return_fields so result['object'] is
+                    # still populated with the canonical record.
+                    try:
+                        fetched = self.connector.get_object(
+                            obj_type=str(target_ref),
+                        )
+                    except Exception:
+                        # Never fail the task because the post-fetch failed;
+                        # the create/update itself already succeeded
+                        # server-side.
+                        pass
+                if fetched:
+                    # get_object on a _ref returns a dict; on a search it
+                    # returns a list. Handle both defensively.
+                    result['object'] = (
+                        fetched[0] if isinstance(fetched, list) else fetched
+                    )
 
         return result
 

--- a/plugins/module_utils/api.py
+++ b/plugins/module_utils/api.py
@@ -107,6 +107,7 @@ NIOS_RETURN_FIELDS_EXCLUDE = frozenset({
     'new_start_addr',      # nios_range
     'new_end_addr',        # nios_range
     'create_token',        # nios_member
+    'password',            # nios_adminuser - WAPI rejects GET return_fields+=password
 })
 
 NIOS_PROVIDER_SPEC = {

--- a/plugins/module_utils/api.py
+++ b/plugins/module_utils/api.py
@@ -96,6 +96,19 @@ NIOS_RETURN_OBJECT_EXCLUDE = frozenset({
     NIOS_MEMBER,
 })
 
+# ib_spec keys that are module-side helpers / write-only inputs and are NOT
+# valid WAPI return fields. They are stripped from the return_fields set
+# passed to the post-write re-fetch in WapiModule.run() (issue #305) so the
+# GET succeeds on the first try. Mirrors the per-type sanitization already
+# performed by get_object_ref() before its own GETs.
+NIOS_RETURN_FIELDS_EXCLUDE = frozenset({
+    'restart_if_needed',   # nios_zone
+    'template',            # nios_network, nios_network_container
+    'new_start_addr',      # nios_range
+    'new_end_addr',        # nios_range
+    'create_token',        # nios_member
+})
+
 NIOS_PROVIDER_SPEC = {
     'host': dict(fallback=(env_fallback, ['INFOBLOX_HOST'])),
     'username': dict(fallback=(env_fallback, ['INFOBLOX_USERNAME'])),
@@ -683,36 +696,25 @@ class WapiModule(WapiBase):
             if target_ref:
                 return_fields = sorted({
                     k for k in ib_spec.keys()
-                    if not k.startswith('_') and k not in ('provider', 'state')
+                    if not k.startswith('_')
+                    and k not in ('provider', 'state')
+                    and k not in NIOS_RETURN_FIELDS_EXCLUDE
                 })
-                fetched = None
                 try:
                     fetched = self.connector.get_object(
                         obj_type=str(target_ref),
                         return_fields=return_fields or None,
                     )
-                except Exception:
-                    # Some modules include helper/read-only ib_spec keys that
-                    # are not valid WAPI return fields (e.g., nios_zone's
-                    # restart_if_needed, nios_network's template,
-                    # nios_range's new_start_addr/new_end_addr). Retry the
-                    # fetch without return_fields so result['object'] is
-                    # still populated with the canonical record.
-                    try:
-                        fetched = self.connector.get_object(
-                            obj_type=str(target_ref),
+                    if fetched:
+                        # get_object on a _ref returns a dict; on a search it
+                        # returns a list. Handle both defensively.
+                        result['object'] = (
+                            fetched[0] if isinstance(fetched, list) else fetched
                         )
-                    except Exception:
-                        # Never fail the task because the post-fetch failed;
-                        # the create/update itself already succeeded
-                        # server-side.
-                        pass
-                if fetched:
-                    # get_object on a _ref returns a dict; on a search it
-                    # returns a list. Handle both defensively.
-                    result['object'] = (
-                        fetched[0] if isinstance(fetched, list) else fetched
-                    )
+                except Exception:
+                    # Never fail the task because the post-fetch failed; the
+                    # create/update itself already succeeded server-side.
+                    pass
 
         return result
 

--- a/plugins/module_utils/api.py
+++ b/plugins/module_utils/api.py
@@ -108,6 +108,8 @@ NIOS_RETURN_FIELDS_EXCLUDE = frozenset({
     'new_end_addr',        # nios_range
     'create_token',        # nios_member
     'password',            # nios_adminuser - WAPI rejects GET return_fields+=password
+    'members',             # nios_network - WAPI rejects GET return_fields+=members
+    'vlans',               # nios_network, nios_vlan - WAPI rejects GET return_fields+=vlans
 })
 
 NIOS_PROVIDER_SPEC = {
@@ -615,7 +617,8 @@ class WapiModule(WapiBase):
                         if ('add' or 'remove') in proposed_object['ipv4addrs'][0]:
                             run_update, proposed_object = self.check_if_add_remove_ip_arg_exists(proposed_object)
                             if run_update:
-                                res = self.update_object(ref, proposed_object)
+                                if not self.module.check_mode:
+                                    res = self.update_object(ref, proposed_object)
                                 result['changed'] = True
                             else:
                                 res = ref
@@ -673,7 +676,8 @@ class WapiModule(WapiBase):
                 if 'ipv4addrs' in proposed_object:
                     if 'remove' in proposed_object['ipv4addrs'][0]:
                         self.check_if_add_remove_ip_arg_exists(proposed_object)
-                        self.update_object(ref, proposed_object)
+                        if not self.module.check_mode:
+                            self.update_object(ref, proposed_object)
                         result['changed'] = True
                 elif not self.module.check_mode:
                     self.delete_object(ref)
@@ -712,10 +716,12 @@ class WapiModule(WapiBase):
                         result['object'] = (
                             fetched[0] if isinstance(fetched, list) else fetched
                         )
-                except Exception:
+                except Exception as exc:
                     # Never fail the task because the post-fetch failed; the
                     # create/update itself already succeeded server-side.
-                    pass
+                    self.module.warn(
+                        'nios post-fetch failed (object was written successfully): %s' % str(exc)
+                    )
 
         return result
 

--- a/tests/unit/plugins/module_utils/test_api.py
+++ b/tests/unit/plugins/module_utils/test_api.py
@@ -691,3 +691,30 @@ class TestNiosApi(unittest.TestCase):
         second_filter = wapi.get_object.call_args_list[1][0][1]
         self.assertIn('network_view', first_filter)
         self.assertNotIn('network_view', second_filter)
+
+    def test_post_fetch_filters_password_for_adminuser(self):
+        # Post-write re-fetch should never request password in return_fields
+        # because WAPI rejects adminuser GETs with return_fields+=password.
+        self.module.params = {
+            'provider': {}, 'state': 'present',
+            'name': 'api-user', 'password': 'secret',
+        }
+        test_spec = {
+            'name': {'ib_req': True},
+            'password': {},
+        }
+
+        wapi = api.WapiModule(self.module)
+        wapi.get_object = Mock(return_value=None)
+        wapi.create_object = Mock(return_value='adminuser/test-ref')
+        wapi.update_object = Mock()
+        wapi.delete_object = Mock()
+        wapi.connector.get_object = Mock(return_value={'_ref': 'adminuser/test-ref', 'name': 'api-user'})
+
+        res = wapi.run(api.NIOS_ADMINUSER, test_spec)
+
+        self.assertTrue(res['changed'])
+        self.assertIn('object', res)
+        called_kwargs = wapi.connector.get_object.call_args.kwargs
+        self.assertIn('return_fields', called_kwargs)
+        self.assertNotIn('password', called_kwargs['return_fields'])

--- a/tests/unit/plugins/module_utils/test_api.py
+++ b/tests/unit/plugins/module_utils/test_api.py
@@ -718,3 +718,172 @@ class TestNiosApi(unittest.TestCase):
         called_kwargs = wapi.connector.get_object.call_args.kwargs
         self.assertIn('return_fields', called_kwargs)
         self.assertNotIn('password', called_kwargs['return_fields'])
+
+    def test_post_fetch_filters_members_and_vlans(self):
+        # Post-write re-fetch must never include 'members' or 'vlans' in
+        # return_fields because WAPI rejects network GETs with those fields.
+        # Using a generic object type to avoid get_object_ref's network-specific
+        # key manipulation; the exclusion is applied unconditionally by run().
+        self.module.params = {
+            'provider': {}, 'state': 'present',
+            'network': '10.0.0.0/24', 'network_view': 'default',
+            'members': [], 'vlans': [],
+        }
+        test_spec = {
+            'network': {'ib_req': True},
+            'network_view': {},
+            'members': {},
+            'vlans': {},
+        }
+
+        wapi = api.WapiModule(self.module)
+        wapi.get_object = Mock(return_value=None)
+        wapi.create_object = Mock(return_value='testnetwork/ZG5z:10.0.0.0/24/default')
+        wapi.update_object = Mock()
+        wapi.delete_object = Mock()
+        wapi.connector.get_object = Mock(return_value={
+            '_ref': 'testnetwork/ZG5z:10.0.0.0/24/default',
+            'network': '10.0.0.0/24',
+        })
+
+        res = wapi.run('testnetwork', test_spec)
+
+        self.assertTrue(res['changed'])
+        self.assertIn('object', res)
+        called_kwargs = wapi.connector.get_object.call_args.kwargs
+        self.assertIn('return_fields', called_kwargs)
+        self.assertNotIn('members', called_kwargs['return_fields'])
+        self.assertNotIn('vlans', called_kwargs['return_fields'])
+
+    def test_post_fetch_skipped_in_check_mode(self):
+        # In check_mode the post-write re-fetch must never be attempted.
+        self.module.check_mode = True
+        self.module.params = {
+            'provider': {}, 'state': 'present',
+            'name': 'check-obj', 'comment': None, 'extattrs': None,
+        }
+        test_spec = {
+            'name': {'ib_req': True},
+            'comment': {},
+            'extattrs': {},
+        }
+
+        wapi = api.WapiModule(self.module)
+        wapi.get_object = Mock(return_value=None)
+        wapi.create_object = Mock(return_value='testobject/check-ref')
+        wapi.update_object = Mock()
+        wapi.delete_object = Mock()
+        wapi.connector.get_object = Mock()
+
+        res = wapi.run('testobject', test_spec)
+
+        self.assertTrue(res['changed'])
+        wapi.connector.get_object.assert_not_called()
+        self.assertNotIn('object', res)
+
+    def test_post_fetch_failure_emits_warning_not_exception(self):
+        # When the post-fetch connector call raises, the module must emit a
+        # warning instead of failing the task (the write already succeeded).
+        self.module.params = {
+            'provider': {}, 'state': 'present',
+            'name': 'new-obj', 'comment': None, 'extattrs': None,
+        }
+        test_spec = {
+            'name': {'ib_req': True},
+            'comment': {},
+            'extattrs': {},
+        }
+
+        wapi = api.WapiModule(self.module)
+        wapi.get_object = Mock(return_value=None)
+        wapi.create_object = Mock(return_value='testobject/new-ref')
+        wapi.update_object = Mock()
+        wapi.delete_object = Mock()
+        wapi.connector.get_object = Mock(side_effect=Exception('connector error'))
+
+        res = wapi.run('testobject', test_spec)
+
+        self.assertTrue(res['changed'])
+        self.assertNotIn('object', res)
+        self.module.warn.assert_called_once()
+        warn_msg = self.module.warn.call_args[0][0]
+        self.assertIn('post-fetch failed', warn_msg)
+        self.assertIn('connector error', warn_msg)
+
+    def test_check_mode_skips_update_in_add_ip_path(self):
+        # In check_mode, the HOST_RECORD add-ip update_object call must be
+        # suppressed, but result['changed'] must still be True.
+        self.module.check_mode = True
+        ref = 'record:host/ZG5z:myhost/default'
+        self.module.params = {
+            'provider': {}, 'state': 'present',
+            'name': 'myhost', 'view': 'default',
+            'configure_for_dns': True,
+            'ipv4addrs': [{'ipv4addr': '10.0.0.2', 'add': True}],
+            'comment': None, 'extattrs': None,
+        }
+        existing = [{
+            '_ref': ref,
+            'name': 'myhost', 'view': 'default',
+            'configure_for_dns': True,
+            'ipv4addrs': [{'ipv4addr': '10.0.0.1'}],
+            'comment': None, 'extattrs': {},
+        }]
+        test_spec = {
+            'name': {'ib_req': True},
+            'view': {'ib_req': True},
+            'configure_for_dns': {'ib_req': True},
+            'ipv4addrs': {},
+            'comment': {},
+            'extattrs': {},
+        }
+
+        wapi = api.WapiModule(self.module)
+        wapi.get_object = Mock(return_value=existing)
+        wapi.create_object = Mock()
+        wapi.update_object = Mock()
+        wapi.delete_object = Mock()
+
+        res = wapi.run(api.NIOS_HOST_RECORD, test_spec)
+
+        self.assertTrue(res['changed'])
+        wapi.update_object.assert_not_called()
+
+    def test_check_mode_skips_update_in_remove_ip_absent_path(self):
+        # In check_mode, the HOST_RECORD remove-ip update_object call on
+        # state=absent must be suppressed, but result['changed'] must be True.
+        self.module.check_mode = True
+        ref = 'record:host/ZG5z:myhost/default'
+        self.module.params = {
+            'provider': {}, 'state': 'absent',
+            'name': 'myhost', 'view': 'default',
+            'configure_for_dns': True,
+            'ipv4addrs': [{'ipv4addr': '10.0.0.1', 'remove': True}],
+            'comment': None, 'extattrs': None,
+        }
+        existing = [{
+            '_ref': ref,
+            'name': 'myhost', 'view': 'default',
+            'configure_for_dns': True,
+            'ipv4addrs': [{'ipv4addr': '10.0.0.1'}, {'ipv4addr': '10.0.0.2'}],
+            'comment': None, 'extattrs': {},
+        }]
+        test_spec = {
+            'name': {'ib_req': True},
+            'view': {'ib_req': True},
+            'configure_for_dns': {'ib_req': True},
+            'ipv4addrs': {},
+            'comment': {},
+            'extattrs': {},
+        }
+
+        wapi = api.WapiModule(self.module)
+        wapi.get_object = Mock(return_value=existing)
+        wapi.create_object = Mock()
+        wapi.update_object = Mock()
+        wapi.delete_object = Mock()
+
+        res = wapi.run(api.NIOS_HOST_RECORD, test_spec)
+
+        self.assertTrue(res['changed'])
+        wapi.update_object.assert_not_called()


### PR DESCRIPTION
After a successful present-state write, WapiModule.run() now re-fetches the canonical object via WAPI and exposes it under result['object']. This makes WAPI-resolved values visible to playbooks - notably IPs allocated by func:nextavailableip and networks allocated by func:nextavailablenetwork - which were previously silently dropped from the module's return value (only {'changed': bool} was returned).

The set of fields requested is derived from each module's ib_spec, so the fix applies uniformly across every WAPI object type without a per-type lookup table that would need maintenance as the schema evolves.

Change is strictly additive:
  - Only a new top-level 'object' key is added to the result.
  - No mutation of existing keys (changed, failed, api_results, ...).
  - No fetch on check_mode, idempotent (changed=false) runs, or absent state.
  - NIOS_MEMBER is excluded (create_token flow already uses api_results).
  - Post-fetch failures are swallowed so a transient GET error never masks a successful create/update.

Fixes: https://github.com/infobloxopen/infoblox-ansible/issues/305