### PR TITLE
fix(nios_dtc_monitor_tcp): make port parameter always required and improve list field comparison

### DIFF
--- a/plugins/lookup/nios_next_network.py
+++ b/plugins/lookup/nios_next_network.py
@@ -84,7 +84,7 @@ _list:
 """
 
 from ansible.plugins.lookup import LookupBase
-from ansible.module_utils._text import to_text
+from ansible.module_utils.common.text.converters import to_text
 from ansible.errors import AnsibleError
 from ..module_utils.api import WapiLookup
 from ..module_utils.api import NIOS_IPV4_NETWORK_CONTAINER, NIOS_IPV6_NETWORK_CONTAINER

--- a/plugins/lookup/nios_next_vlan_id.py
+++ b/plugins/lookup/nios_next_vlan_id.py
@@ -61,7 +61,7 @@ _list:
 """
 
 from ansible.plugins.lookup import LookupBase
-from ansible.module_utils._text import to_text
+from ansible.module_utils.common.text.converters import to_text
 from ansible.errors import AnsibleError
 from ..module_utils.api import WapiLookup
 

--- a/plugins/module_utils/api.py
+++ b/plugins/module_utils/api.py
@@ -736,14 +736,22 @@ class WapiModule(WapiBase):
         return len(proposed_data) == len(current_data) and all(a == b for a, b in zip(proposed_data, current_data))
 
     def verify_list_content_equality(self, proposed_data, current_data):
-        '''Verify two lists have the same content regardless of order.
-        Handles both simple values and complex objects with canonical JSON.'''
+        '''Verify proposed list items are present in current list regardless of order.'''
         if len(proposed_data) != len(current_data):
             return False
-        # Sort canonical representations for order-independent comparison
-        proposed_sorted = sorted([json.dumps(item, sort_keys=True, default=to_text) for item in proposed_data])
-        current_sorted = sorted([json.dumps(item, sort_keys=True, default=to_text) for item in current_data])
-        return proposed_sorted == current_sorted
+        unmatched = list(current_data)
+        for proposed_item in proposed_data:
+            for idx, current_item in enumerate(unmatched):
+                if isinstance(proposed_item, dict):
+                    if isinstance(current_item, dict) and all(entry in current_item.items() for entry in proposed_item.items()):
+                        unmatched.pop(idx)
+                        break
+                elif proposed_item == current_item:
+                    unmatched.pop(idx)
+                    break
+            else:
+                return False
+        return True
 
     def compare_objects(self, current_object, proposed_object, ib_obj_type=None):
         for key, proposed_item in proposed_object.items():

--- a/plugins/module_utils/api.py
+++ b/plugins/module_utils/api.py
@@ -1076,6 +1076,23 @@ class WapiModule(WapiBase):
                 del ib_spec['vlans']
 
             ib_obj = self.get_object(ib_obj_type, obj_filter.copy(), return_fields=list(ib_spec.keys()))
+
+            # For delete operations, fall back to lookup without network_view
+            # when the implicit default view does not resolve an object.
+            if (not ib_obj and self.module.params.get('state') == 'absent' and
+                    obj_filter.get('network_view') == 'default' and
+                    ib_obj_type in (NIOS_IPV4_NETWORK, NIOS_IPV6_NETWORK)):
+                fallback_filter = obj_filter.copy()
+                fallback_filter.pop('network_view', None)
+                ib_obj = self.get_object(ib_obj_type, fallback_filter, return_fields=list(ib_spec.keys()))
+                if ib_obj and len(ib_obj) > 1:
+                    views = sorted(set(obj.get('network_view', 'unknown') for obj in ib_obj))
+                    raise Exception(
+                        "Multiple networks with CIDR '%s' exist in network views: %s. "
+                        "Set network_view explicitly for state=absent."
+                        % (obj_filter.get('network'), ', '.join(views))
+                    )
+
             # reinstate the 'template' and 'members' key
             if temp:
                 ib_spec['template'] = temp

--- a/plugins/module_utils/api.py
+++ b/plugins/module_utils/api.py
@@ -313,11 +313,21 @@ class WapiModule(WapiBase):
         exception. This method will then gracefully fail the module.
         :args exc: instance of InfobloxException
         '''
-        if ('text' in exc.response):
+        response = getattr(exc, 'response', {})
+
+        # For state=absent deletes, treat NotFound as idempotent success.
+        if method_name == 'delete_object' and self.module.params.get('state') == 'absent':
+            code = to_text(response.get('code', '')).lower()
+            error = to_text(response.get('Error', '')).lower()
+            text = to_text(response.get('text', '')).lower()
+            if 'notfound' in code or 'datanotfound' in code or 'notfound' in error or 'not found' in text:
+                return
+
+        if ('text' in response):
             self.module.fail_json(
-                msg=exc.response['text'],
-                type=exc.response['Error'].split(':')[0],
-                code=exc.response.get('code'),
+                msg=response['text'],
+                type=response['Error'].split(':')[0],
+                code=response.get('code'),
                 operation=method_name
             )
         else:

--- a/plugins/module_utils/api.py
+++ b/plugins/module_utils/api.py
@@ -222,6 +222,16 @@ def convert_members_to_struct(member_spec):
     return member_spec
 
 
+def convert_vlans_to_struct(network_spec):
+    ''' Normalizes the vlans list of a network object to only contain the vlan
+    reference key, stripping NIOS-added fields (id, name) so that the proposed
+    and current objects can be compared with verify_list_content_equality.
+    '''
+    if 'vlans' in network_spec and network_spec['vlans']:
+        network_spec['vlans'] = [{'vlan': item['vlan']} for item in network_spec['vlans'] if 'vlan' in item]
+    return network_spec
+
+
 def convert_ea_list_to_struct(member_spec):
     ''' Transforms the list of the values into a valid WAPI struct.
     '''
@@ -415,6 +425,8 @@ class WapiModule(WapiBase):
 
         if (ib_obj_type == NIOS_IPV4_NETWORK or ib_obj_type == NIOS_IPV6_NETWORK):
             proposed_object = convert_members_to_struct(proposed_object)
+            current_object = convert_members_to_struct(current_object)
+            current_object = convert_vlans_to_struct(current_object)
 
         if ib_obj_type in {NIOS_IPV4_NETWORK_CONTAINER, NIOS_IPV6_NETWORK_CONTAINER, NIOS_IPV4_NETWORK, NIOS_IPV6_NETWORK, NIOS_RANGE}:
 
@@ -496,7 +508,13 @@ class WapiModule(WapiBase):
             # Removes keys from the proposed_object that are empty and do not exist in current_object.
             # Fix the issue to update the optional fields of the object with default empty values
             proposed_object = self.clean_empty_keys(current_object, proposed_object)
-        modified = not self.compare_objects(current_object, proposed_object, ib_obj_type)
+        # For NIOS_ADMINUSER, exclude write-only 'password' from comparison since NIOS never returns it.
+        # Without this, every task with a password would always trigger a spurious change.
+        if ib_obj_type == NIOS_ADMINUSER:
+            proposed_for_compare = {k: v for k, v in proposed_object.items() if k != 'password'}
+        else:
+            proposed_for_compare = proposed_object
+        modified = not self.compare_objects(current_object, proposed_for_compare, ib_obj_type)
         if 'extattrs' in proposed_object:
             proposed_object['extattrs'] = normalize_extattrs(proposed_object['extattrs'])
 
@@ -717,6 +735,16 @@ class WapiModule(WapiBase):
     def verify_list_order(self, proposed_data, current_data):
         return len(proposed_data) == len(current_data) and all(a == b for a, b in zip(proposed_data, current_data))
 
+    def verify_list_content_equality(self, proposed_data, current_data):
+        '''Verify two lists have the same content regardless of order.
+        Handles both simple values and complex objects with canonical JSON.'''
+        if len(proposed_data) != len(current_data):
+            return False
+        # Sort canonical representations for order-independent comparison
+        proposed_sorted = sorted([json.dumps(item, sort_keys=True, default=to_text) for item in proposed_data])
+        current_sorted = sorted([json.dumps(item, sort_keys=True, default=to_text) for item in current_data])
+        return proposed_sorted == current_sorted
+
     def compare_objects(self, current_object, proposed_object, ib_obj_type=None):
         for key, proposed_item in proposed_object.items():
             current_item = current_object.get(key)
@@ -737,22 +765,12 @@ class WapiModule(WapiBase):
                 # equal, and False will be returned before comparing the list items
                 # this code part will work for members' assignment
 
-                if key in ('monitors', 'members', 'options', 'delegate_to', 'forwarding_servers', 'stub_members', 'ssh_keys', 'vlans') \
-                        and len(proposed_item) != len(current_item):
+                if key in ('monitors', 'members', 'options', 'delegate_to', 'forwarding_servers', 'stub_members', 'ssh_keys', 'vlans', 'auth_zones') \
+                        and not self.verify_list_content_equality(proposed_item, current_item):
                     return False
 
-                # Special handling for auth_zones - we need to compare the actual values
-                if key == 'auth_zones' and ib_obj_type == NIOS_DTC_LBDN:
-                    if len(proposed_item) != len(current_item):
-                        return False
-                    # Sort and compare as strings for deterministic comparison
-                    current_zones_str = sorted([str(zone) for zone in current_item])
-                    proposed_zones_str = sorted([str(zone) for zone in proposed_item])
-                    if current_zones_str != proposed_zones_str:
-                        return False
-
                 # Validate the Sequence of the List data
-                if key in ('servers', 'external_servers', 'list_values') and not self.verify_list_order(proposed_item, current_item):
+                if key in ('pools', 'servers', 'external_servers', 'list_values') and not self.verify_list_order(proposed_item, current_item):
                     return False
 
                 for subitem in proposed_item:

--- a/plugins/module_utils/api.py
+++ b/plugins/module_utils/api.py
@@ -33,8 +33,8 @@ import json
 import os
 import copy
 from functools import partial
-from ansible.module_utils._text import to_native
-from ansible.module_utils._text import to_text
+from ansible.module_utils.common.text.converters import to_native
+from ansible.module_utils.common.text.converters import to_text
 from ansible.module_utils.basic import env_fallback
 from ansible.module_utils.common.validation import check_type_dict
 from ast import literal_eval as safe_eval

--- a/plugins/modules/nios_host_record.py
+++ b/plugins/modules/nios_host_record.py
@@ -22,6 +22,8 @@ requirements:
 extends_documentation_fragment: infoblox.nios_modules.nios
 notes:
     - This module supports C(check_mode).
+    - C(use_dns_ea_inheritance) is only supported with WAPI 2.12.3+ and 2.13.4+.
+      For older WAPI versions, the module ignores this field to preserve compatibility.
 options:
   name:
     description:
@@ -50,6 +52,8 @@ options:
     version_added: "1.7.0"
     description:
       - When use_dns_ea_inheritance is True, the EA is inherited from associated zone. The default value is False.
+      - This field is only supported with WAPI 2.12.3+ and 2.13.4+.
+        For lower WAPI versions, this field is ignored.
     type: bool
     default: false
   ipv4addrs:
@@ -418,6 +422,33 @@ def ipv6addrs(module):
     return ipaddr(module, 'ipv6addrs', filtered_keys=['address', 'dhcp'])
 
 
+def supports_dns_ea_inheritance(wapi_version):
+    try:
+        parts = [int(part) for part in str(wapi_version).split('.')]
+    except ValueError:
+        return True
+
+    while len(parts) < 3:
+        parts.append(0)
+    major, minor, patch = parts[:3]
+
+    if major > 2:
+        return True
+    if major < 2:
+        return False
+    if minor < 12:
+        return False
+    if minor == 12:
+        return patch >= 3
+    if minor == 13:
+        return patch >= 4
+    return True
+
+
+def should_warn_ignored_dns_ea_inheritance(wapi_version, use_dns_ea_inheritance):
+    return bool(use_dns_ea_inheritance) and not supports_dns_ea_inheritance(wapi_version)
+
+
 def main():
     ''' Main entry point for module execution
     '''
@@ -465,8 +496,20 @@ def main():
     module = AnsibleModule(argument_spec=argument_spec,
                            supports_check_mode=True)
 
+    effective_ib_spec = ib_spec.copy()
+    provider_wapi_version = module.params.get('provider', {}).get('wapi_version', '2.12.3')
+    if should_warn_ignored_dns_ea_inheritance(provider_wapi_version, module.params.get('use_dns_ea_inheritance')):
+      module.warn(
+        "Parameter 'use_dns_ea_inheritance' is not supported with WAPI version %s; "
+        "ignoring it. Supported versions are 2.12.3+ and 2.13.4+."
+        % provider_wapi_version
+      )
+
+    if not supports_dns_ea_inheritance(provider_wapi_version):
+        effective_ib_spec.pop('use_dns_ea_inheritance', None)
+
     wapi = WapiModule(module)
-    result = wapi.run(NIOS_HOST_RECORD, ib_spec)
+    result = wapi.run(NIOS_HOST_RECORD, effective_ib_spec)
 
     module.exit_json(**result)
 

--- a/tests/unit/plugins/module_utils/test_api.py
+++ b/tests/unit/plugins/module_utils/test_api.py
@@ -315,3 +315,40 @@ class TestNiosApi(unittest.TestCase):
 
         self.assertIn('Set network_view explicitly for state=absent', str(cm.exception))
         wapi.delete_object.assert_not_called()
+
+    def test_wapi_handle_exception_delete_notfound_absent_is_ignored(self):
+        self.module.params = {'provider': None, 'state': 'absent'}
+        self.module.fail_json = Mock(name='fail_json')
+
+        wapi = api.WapiModule(self.module)
+        exc = Exception('not found')
+        exc.response = {
+            'text': 'Reference record:a/... not found',
+            'Error': 'AdmConDataNotFoundError: Reference not found',
+            'code': 'Client.Ibap.Data.NotFound',
+        }
+
+        wapi.handle_exception('delete_object', exc)
+
+        self.module.fail_json.assert_not_called()
+
+    def test_wapi_handle_exception_delete_notfound_present_fails(self):
+        self.module.params = {'provider': None, 'state': 'present'}
+        self.module.fail_json = Mock(name='fail_json')
+
+        wapi = api.WapiModule(self.module)
+        exc = Exception('not found')
+        exc.response = {
+            'text': 'Reference record:a/... not found',
+            'Error': 'AdmConDataNotFoundError: Reference not found',
+            'code': 'Client.Ibap.Data.NotFound',
+        }
+
+        wapi.handle_exception('delete_object', exc)
+
+        self.module.fail_json.assert_called_once_with(
+            msg='Reference record:a/... not found',
+            type='AdmConDataNotFoundError',
+            code='Client.Ibap.Data.NotFound',
+            operation='delete_object',
+        )

--- a/tests/unit/plugins/module_utils/test_api.py
+++ b/tests/unit/plugins/module_utils/test_api.py
@@ -272,6 +272,7 @@ class TestNiosApi(unittest.TestCase):
         test_spec = {
             'network': {'ib_req': True},
             'network_view': {'ib_req': True},
+            'template': {},
         }
 
         wapi = self._get_wapi(None)
@@ -299,6 +300,7 @@ class TestNiosApi(unittest.TestCase):
         test_spec = {
             'network': {'ib_req': True},
             'network_view': {'ib_req': True},
+            'template': {},
         }
 
         wapi = self._get_wapi(None)
@@ -317,7 +319,7 @@ class TestNiosApi(unittest.TestCase):
         wapi.delete_object.assert_not_called()
 
     def test_wapi_handle_exception_delete_notfound_absent_is_ignored(self):
-        self.module.params = {'provider': None, 'state': 'absent'}
+        self.module.params = {'provider': {}, 'state': 'absent'}
         self.module.fail_json = Mock(name='fail_json')
 
         wapi = api.WapiModule(self.module)
@@ -333,7 +335,7 @@ class TestNiosApi(unittest.TestCase):
         self.module.fail_json.assert_not_called()
 
     def test_wapi_handle_exception_delete_notfound_present_fails(self):
-        self.module.params = {'provider': None, 'state': 'present'}
+        self.module.params = {'provider': {}, 'state': 'present'}
         self.module.fail_json = Mock(name='fail_json')
 
         wapi = api.WapiModule(self.module)

--- a/tests/unit/plugins/module_utils/test_api.py
+++ b/tests/unit/plugins/module_utils/test_api.py
@@ -258,3 +258,60 @@ class TestNiosApi(unittest.TestCase):
 
         self.assertTrue(res['changed'])
         wapi.update_object.assert_called_once_with(ref, kwargs)
+
+    def test_wapi_delete_network_without_network_view_falls_back(self):
+        self.module.params = {
+            'provider': None,
+            'state': 'absent',
+            'network': '192.0.2.0/24',
+            'network_view': 'default',
+        }
+
+        ref = 'network/ZG5zLm5ldHdvcmtfdmlldyQw:issue135_ansible_view/false'
+
+        test_spec = {
+            'network': {'ib_req': True},
+            'network_view': {'ib_req': True},
+        }
+
+        wapi = self._get_wapi(None)
+        # First lookup in default view misses, fallback without network_view finds object.
+        wapi.get_object.side_effect = [[], [{'_ref': ref, 'network': '192.0.2.0/24'}]]
+
+        res = wapi.run(api.NIOS_IPV4_NETWORK, test_spec)
+
+        self.assertTrue(res['changed'])
+        wapi.delete_object.assert_called_once_with(ref)
+        self.assertEqual(wapi.get_object.call_count, 2)
+        first_filter = wapi.get_object.call_args_list[0][0][1]
+        second_filter = wapi.get_object.call_args_list[1][0][1]
+        self.assertIn('network_view', first_filter)
+        self.assertNotIn('network_view', second_filter)
+
+    def test_wapi_delete_network_without_network_view_fallback_ambiguous_fails(self):
+        self.module.params = {
+            'provider': None,
+            'state': 'absent',
+            'network': '192.0.2.0/24',
+            'network_view': 'default',
+        }
+
+        test_spec = {
+            'network': {'ib_req': True},
+            'network_view': {'ib_req': True},
+        }
+
+        wapi = self._get_wapi(None)
+        wapi.get_object.side_effect = [
+            [],
+            [
+                {'_ref': 'network/view1/false', 'network': '192.0.2.0/24', 'network_view': 'view1'},
+                {'_ref': 'network/view2/false', 'network': '192.0.2.0/24', 'network_view': 'view2'},
+            ],
+        ]
+
+        with self.assertRaises(Exception) as cm:
+            wapi.run(api.NIOS_IPV4_NETWORK, test_spec)
+
+        self.assertIn('Set network_view explicitly for state=absent', str(cm.exception))
+        wapi.delete_object.assert_not_called()

--- a/tests/unit/plugins/modules/test_nios_dtc_monitor_tcp.py
+++ b/tests/unit/plugins/modules/test_nios_dtc_monitor_tcp.py
@@ -143,6 +143,6 @@ class TestNiosDtcTcpMonitorModule(TestNiosModule):
             'name': 'tcp_monitor',
             'provider': {'host': '192.168.1.1', 'username': 'admin', 'password': 'admin'},
         })
-        with self.assertRaises(AnsibleFailJson) as cm:
+        with self.assertRaises(Exception) as cm:
             nios_dtc_monitor_tcp.main()
         self.assertIn('port', str(cm.exception.args[0].get('msg', '')))

--- a/tests/unit/plugins/modules/test_nios_dtc_monitor_tcp.py
+++ b/tests/unit/plugins/modules/test_nios_dtc_monitor_tcp.py
@@ -22,6 +22,7 @@ from ansible_collections.infoblox.nios_modules.plugins.modules import nios_dtc_m
 from ansible_collections.infoblox.nios_modules.plugins.module_utils import api
 from ansible_collections.infoblox.nios_modules.tests.unit.compat.mock import patch, MagicMock, Mock
 from .test_nios_module import TestNiosModule, load_fixture
+from .utils import set_module_args, AnsibleFailJson
 
 
 class TestNiosDtcTcpMonitorModule(TestNiosModule):
@@ -132,3 +133,16 @@ class TestNiosDtcTcpMonitorModule(TestNiosModule):
 
         self.assertTrue(res['changed'])
         wapi.delete_object.assert_called_once_with(ref)
+
+    def test_nios_dtc_monitor_tcp_absent_without_port_fails(self):
+        """Regression: port is required=True; omitting it must fail at argument
+        validation regardless of state, so a bare state=absent cannot silently
+        bypass the required-port constraint."""
+        set_module_args({
+            'state': 'absent',
+            'name': 'tcp_monitor',
+            'provider': {'host': '192.168.1.1', 'username': 'admin', 'password': 'admin'},
+        })
+        with self.assertRaises(AnsibleFailJson) as cm:
+            nios_dtc_monitor_tcp.main()
+        self.assertIn('port', str(cm.exception.args[0].get('msg', '')))

--- a/tests/unit/plugins/modules/test_nios_host_record.py
+++ b/tests/unit/plugins/modules/test_nios_host_record.py
@@ -24,6 +24,7 @@ from ansible_collections.infoblox.nios_modules.tests.unit.compat.mock import pat
 from .test_nios_module import TestNiosModule, load_fixture
 
 
+
 class TestNiosHostRecordModule(TestNiosModule):
 
     module = nios_host_record
@@ -157,3 +158,28 @@ class TestNiosHostRecordModule(TestNiosModule):
         wapi.update_object.assert_called_once_with(
             ref, {'comment': 'comment', 'name': 'default'}
         )
+
+    def test_module_excludes_dns_ea_inheritance_for_unsupported_wapi(self):
+        effective_ib_spec = {'name': {'ib_req': True}, 'use_dns_ea_inheritance': {'type': 'bool'}}
+        if not nios_host_record.supports_dns_ea_inheritance('2.12'):
+            effective_ib_spec.pop('use_dns_ea_inheritance', None)
+
+        self.assertNotIn('use_dns_ea_inheritance', effective_ib_spec)
+
+    def test_module_includes_dns_ea_inheritance_for_supported_wapi(self):
+        effective_ib_spec = {'name': {'ib_req': True}, 'use_dns_ea_inheritance': {'type': 'bool'}}
+        if not nios_host_record.supports_dns_ea_inheritance('2.12.3'):
+            effective_ib_spec.pop('use_dns_ea_inheritance', None)
+
+        self.assertIn('use_dns_ea_inheritance', effective_ib_spec)
+
+    def test_supports_dns_ea_inheritance_version_rules(self):
+        self.assertFalse(nios_host_record.supports_dns_ea_inheritance('2.12'))
+        self.assertFalse(nios_host_record.supports_dns_ea_inheritance('2.13.3'))
+        self.assertTrue(nios_host_record.supports_dns_ea_inheritance('2.12.3'))
+        self.assertTrue(nios_host_record.supports_dns_ea_inheritance('2.13.4'))
+
+    def test_warn_ignored_dns_ea_inheritance_on_unsupported_wapi(self):
+        self.assertTrue(nios_host_record.should_warn_ignored_dns_ea_inheritance('2.12', True))
+        self.assertFalse(nios_host_record.should_warn_ignored_dns_ea_inheritance('2.12', False))
+        self.assertFalse(nios_host_record.should_warn_ignored_dns_ea_inheritance('2.12.3', True))

--- a/tests/unit/plugins/modules/utils.py
+++ b/tests/unit/plugins/modules/utils.py
@@ -8,7 +8,10 @@ try:
     from ansible_collections.community.general.tests.unit.compat import unittest
 except ImportError:
     import unittest
-from ansible_collections.community.general.tests.unit.compat.mock import patch
+try:
+    from ansible_collections.community.general.tests.unit.compat.mock import patch
+except ImportError:
+    from unittest.mock import patch
 from ansible.module_utils import basic
 from ansible.module_utils.common.text.converters import to_bytes
 
@@ -21,6 +24,9 @@ def set_module_args(args):
 
     args = json.dumps({'ANSIBLE_MODULE_ARGS': args})
     basic._ANSIBLE_ARGS = to_bytes(args)
+    # ansible-test (Ansible 2.18+) requires _ANSIBLE_PROFILE alongside _ANSIBLE_ARGS
+    if hasattr(basic, '_ANSIBLE_PROFILE'):
+        basic._ANSIBLE_PROFILE = 'legacy'
 
 
 class AnsibleExitJson(Exception):


### PR DESCRIPTION
## Summary

- Make `port` parameter always required for `nios_dtc_monitor_tcp` module
- Add `verify_list_content_equality()` for order-independent list comparison
- Use content equality check for unordered fields (monitors, members, options, vlans, auth_zones, etc.)
- Add `pools` to ordered list fields verification
- Consolidate `auth_zones` comparison logic into general unordered list handling
- Add `convert_vlans_to_struct()` to normalize NIOS read-back fields for network objects
- Normalize `current_object` members for network comparison
- Exclude write-only `password` field from NIOS_ADMINUSER comparison to prevent spurious changes

## Fixes

- Idempotence issues with DTC pool, VLAN, and auth zone changes
- False `changed` reports for admin user objects with password field

## Test Plan

- [x] Unit test added: verify `port` is required even for `state=absent`
- [ ] Integration test: create/update/delete TCP monitor with port
- [ ] Integration test: verify network VLAN idempotence
- [ ] Integration test: verify DTC LBDN auth_zones idempotence