### PR TITLE
Bug fixes

### DIFF
--- a/changelogs/fragments/135-nios_network-delete-by-cidr.yml
+++ b/changelogs/fragments/135-nios_network-delete-by-cidr.yml
@@ -1,0 +1,9 @@
+---
+bugfixes:
+  - nios_network module - when ``state=absent`` is used and ``network_view`` is
+    not specified, the module now falls back to a network-only lookup so that
+    the resource can be deleted by CIDR alone. The previous behavior required
+    ``network_view`` and silently no-op'd otherwise. If the CIDR is present
+    in multiple network views, the module fails with a clear ambiguity error
+    so callers can re-run with ``network_view`` set
+    (https://github.com/infobloxopen/infoblox-ansible/issues/135).

--- a/changelogs/fragments/139-delete-object-notfound-idempotent.yml
+++ b/changelogs/fragments/139-delete-object-notfound-idempotent.yml
@@ -1,0 +1,8 @@
+---
+bugfixes:
+  - WapiModule - ``state=absent`` is now idempotent when the underlying NIOS
+    object is missing. Previously a ``NotFound`` returned by the WAPI during
+    the delete call propagated as a task failure even though the desired end
+    state was already true. The delete path now treats ``NotFound`` as
+    ``changed=False`` so re-runs and concurrent deletions do not fail
+    (https://github.com/infobloxopen/infoblox-ansible/issues/139).

--- a/changelogs/fragments/321-handle-exception-hardening.yml
+++ b/changelogs/fragments/321-handle-exception-hardening.yml
@@ -1,0 +1,11 @@
+---
+bugfixes:
+  - WapiModule.handle_exception - guard against NIOS WAPI error responses that
+    omit the ``Error`` key. Previously
+    ``response['Error'].split(':')[0]`` raised a ``KeyError`` when the WAPI
+    returned a JSON body containing only ``text``/``code`` (for example on
+    certain TLS/auth failures), masking the real failure reason.
+  - WapiLookup.handle_exception - guard against ``ConnectionError`` instances
+    whose ``response`` attribute is ``None``. Previously
+    ``if 'text' in exc.response:`` raised an ``AttributeError`` when the
+    exception had no associated response payload, masking the original error.

--- a/changelogs/fragments/321-nios-adminuser-password-idempotent.yml
+++ b/changelogs/fragments/321-nios-adminuser-password-idempotent.yml
@@ -1,0 +1,8 @@
+---
+bugfixes:
+  - nios_admin_user module - ``password`` is now excluded from the
+    proposed-vs-current diff used by ``compare_objects``. The NIOS WAPI never
+    returns the password on a GET, so including it caused every idempotent
+    run to report ``changed=true`` and re-send an update with the same
+    secret. Passwords are still sent on the initial ``create`` and on
+    explicit ``update`` calls (https://github.com/infobloxopen/infoblox-ansible/pull/321).

--- a/changelogs/fragments/321-nios-host-record-use-dns-ea-inheritance-wapi-gating.yml
+++ b/changelogs/fragments/321-nios-host-record-use-dns-ea-inheritance-wapi-gating.yml
@@ -1,0 +1,10 @@
+---
+bugfixes:
+  - nios_host_record module - ``use_dns_ea_inheritance`` is now gated on the
+    WAPI version reported by the provider. The field was introduced in NIOS
+    WAPI 2.12.3 and 2.13.4; sending it against an earlier WAPI causes NIOS
+    to silently drop it, which previously misled callers into believing the
+    inheritance flag had been persisted. On unsupported WAPI versions the
+    module now strips the field from the request and, when the user has
+    explicitly enabled the field, emits a warning explaining that it has
+    been ignored (https://github.com/infobloxopen/infoblox-ansible/pull/321).

--- a/changelogs/fragments/321-vlans-auth-zones-content-equality.yml
+++ b/changelogs/fragments/321-vlans-auth-zones-content-equality.yml
@@ -1,0 +1,16 @@
+---
+minor_changes:
+  - WapiModule.compare_objects - list-valued fields whose order is not
+    semantically meaningful (``monitors``, ``members``, ``options``,
+    ``delegate_to``, ``forwarding_servers``, ``stub_members``, ``ssh_keys``,
+    ``vlans``, ``auth_zones``) are now compared with a dict-subset,
+    order-insensitive algorithm. This eliminates spurious ``changed=true``
+    results when NIOS returns the same content in a different order.
+  - WapiModule.compare_objects - ``pools`` is now compared as an
+    order-sensitive list because DTC LBDN pool order determines priority and
+    weight, so a reordering must register as a change.
+bugfixes:
+  - WapiModule - ``vlans`` on network objects are now normalized to keep only
+    the ``vlan`` reference key on the current object before comparison,
+    stripping NIOS-added ``id`` and ``name`` fields that previously caused
+    false diffs on idempotent runs.

--- a/plugins/lookup/nios_next_network.py
+++ b/plugins/lookup/nios_next_network.py
@@ -84,7 +84,7 @@ _list:
 """
 
 from ansible.plugins.lookup import LookupBase
-from ansible.module_utils._text import to_text
+from ansible.module_utils.common.text.converters import to_text
 from ansible.errors import AnsibleError
 from ..module_utils.api import WapiLookup
 from ..module_utils.api import NIOS_IPV4_NETWORK_CONTAINER, NIOS_IPV6_NETWORK_CONTAINER

--- a/plugins/lookup/nios_next_vlan_id.py
+++ b/plugins/lookup/nios_next_vlan_id.py
@@ -61,7 +61,7 @@ _list:
 """
 
 from ansible.plugins.lookup import LookupBase
-from ansible.module_utils._text import to_text
+from ansible.module_utils.common.text.converters import to_text
 from ansible.errors import AnsibleError
 from ..module_utils.api import WapiLookup
 

--- a/plugins/module_utils/api.py
+++ b/plugins/module_utils/api.py
@@ -542,7 +542,13 @@ class WapiModule(WapiBase):
             # Removes keys from the proposed_object that are empty and do not exist in current_object.
             # Fix the issue to update the optional fields of the object with default empty values
             proposed_object = self.clean_empty_keys(current_object, proposed_object)
-        modified = not self.compare_objects(current_object, proposed_object, ib_obj_type)
+        # For NIOS_ADMINUSER, exclude write-only 'password' from comparison since NIOS never returns it.
+        # Without this, every task with a password would always trigger a spurious change.
+        if ib_obj_type == NIOS_ADMINUSER:
+            proposed_for_compare = {k: v for k, v in proposed_object.items() if k != 'password'}
+        else:
+            proposed_for_compare = proposed_object
+        modified = not self.compare_objects(current_object, proposed_for_compare, ib_obj_type)
         if 'extattrs' in proposed_object:
             proposed_object['extattrs'] = normalize_extattrs(proposed_object['extattrs'])
 

--- a/plugins/module_utils/api.py
+++ b/plugins/module_utils/api.py
@@ -1152,6 +1152,29 @@ class WapiModule(WapiBase):
                 del ib_spec['vlans']
 
             ib_obj = self.get_object(ib_obj_type, obj_filter.copy(), return_fields=list(ib_spec.keys()))
+
+            # Issue #135: For delete operations, fall back to lookup without
+            # network_view when the default view does not resolve an object.
+            # NIOS may not store/return network_view for objects in the default
+            # view, so the filtered query can miss them. Users working solely in
+            # the default view should not need to set network_view explicitly
+            # for deletes. Safety: if the viewless lookup finds the same CIDR in
+            # multiple views, we raise an error requiring the user to be
+            # explicit.
+            if (not ib_obj and self.module.params.get('state') == 'absent' and
+                    obj_filter.get('network_view') == 'default' and
+                    ib_obj_type in (NIOS_IPV4_NETWORK, NIOS_IPV6_NETWORK)):
+                fallback_filter = obj_filter.copy()
+                fallback_filter.pop('network_view', None)
+                ib_obj = self.get_object(ib_obj_type, fallback_filter, return_fields=list(ib_spec.keys()))
+                if ib_obj and len(ib_obj) > 1:
+                    views = sorted(set(obj.get('network_view', 'unknown') for obj in ib_obj))
+                    self.module.fail_json(
+                        msg="Multiple networks with CIDR '%s' exist in network views: %s. "
+                            "Set network_view explicitly for state=absent."
+                            % (obj_filter.get('network'), ', '.join(views))
+                    )
+
             # reinstate the 'template' and 'members' key
             if temp:
                 ib_spec['template'] = temp

--- a/plugins/module_utils/api.py
+++ b/plugins/module_utils/api.py
@@ -471,6 +471,7 @@ class WapiModule(WapiBase):
 
         if (ib_obj_type == NIOS_IPV4_NETWORK or ib_obj_type == NIOS_IPV6_NETWORK):
             proposed_object = convert_members_to_struct(proposed_object)
+            proposed_object = convert_vlans_to_struct(proposed_object)
             current_object = convert_members_to_struct(current_object)
             current_object = convert_vlans_to_struct(current_object)
 

--- a/plugins/module_utils/api.py
+++ b/plugins/module_utils/api.py
@@ -280,8 +280,9 @@ class WapiBase(object):
 class WapiLookup(WapiBase):
     ''' Implements WapiBase for lookup plugins '''
     def handle_exception(self, method_name, exc):
-        if ('text' in exc.response):
-            raise Exception(exc.response['text'])
+        response = getattr(exc, 'response', None) or {}
+        if 'text' in response:
+            raise Exception(response['text'])
         else:
             raise Exception(exc)
 
@@ -326,7 +327,7 @@ class WapiModule(WapiBase):
         if ('text' in response):
             self.module.fail_json(
                 msg=response['text'],
-                type=response['Error'].split(':')[0],
+                type=response.get('Error', '').split(':')[0],
                 code=response.get('code'),
                 operation=method_name
             )

--- a/plugins/module_utils/api.py
+++ b/plugins/module_utils/api.py
@@ -222,6 +222,16 @@ def convert_members_to_struct(member_spec):
     return member_spec
 
 
+def convert_vlans_to_struct(network_spec):
+    ''' Normalizes the vlans list of a network object to only contain the vlan
+    reference key, stripping NIOS-added fields (id, name) so that the proposed
+    and current objects can be compared with verify_list_content_equality.
+    '''
+    if 'vlans' in network_spec and network_spec['vlans']:
+        network_spec['vlans'] = [{'vlan': item['vlan']} for item in network_spec['vlans'] if 'vlan' in item]
+    return network_spec
+
+
 def convert_ea_list_to_struct(member_spec):
     ''' Transforms the list of the values into a valid WAPI struct.
     '''
@@ -461,6 +471,8 @@ class WapiModule(WapiBase):
 
         if (ib_obj_type == NIOS_IPV4_NETWORK or ib_obj_type == NIOS_IPV6_NETWORK):
             proposed_object = convert_members_to_struct(proposed_object)
+            current_object = convert_members_to_struct(current_object)
+            current_object = convert_vlans_to_struct(current_object)
 
         if ib_obj_type in {NIOS_IPV4_NETWORK_CONTAINER, NIOS_IPV6_NETWORK_CONTAINER, NIOS_IPV4_NETWORK, NIOS_IPV6_NETWORK, NIOS_RANGE}:
 
@@ -769,6 +781,24 @@ class WapiModule(WapiBase):
     def verify_list_order(self, proposed_data, current_data):
         return len(proposed_data) == len(current_data) and all(a == b for a, b in zip(proposed_data, current_data))
 
+    def verify_list_content_equality(self, proposed_data, current_data):
+        '''Verify proposed list items are present in current list regardless of order.'''
+        if len(proposed_data) != len(current_data):
+            return False
+        unmatched = list(current_data)
+        for proposed_item in proposed_data:
+            for idx, current_item in enumerate(unmatched):
+                if isinstance(proposed_item, dict):
+                    if isinstance(current_item, dict) and all(entry in current_item.items() for entry in proposed_item.items()):
+                        unmatched.pop(idx)
+                        break
+                elif proposed_item == current_item:
+                    unmatched.pop(idx)
+                    break
+            else:
+                return False
+        return True
+
     def compare_objects(self, current_object, proposed_object, ib_obj_type=None):
         for key, proposed_item in proposed_object.items():
             current_item = current_object.get(key)
@@ -789,22 +819,13 @@ class WapiModule(WapiBase):
                 # equal, and False will be returned before comparing the list items
                 # this code part will work for members' assignment
 
-                if key in ('monitors', 'members', 'options', 'delegate_to', 'forwarding_servers', 'stub_members', 'ssh_keys', 'vlans') \
-                        and len(proposed_item) != len(current_item):
+                if key in ('monitors', 'members', 'options', 'delegate_to', 'forwarding_servers', 'stub_members', 'ssh_keys', 'vlans', 'auth_zones') \
+                        and not self.verify_list_content_equality(proposed_item, current_item):
                     return False
 
-                # Special handling for auth_zones - we need to compare the actual values
-                if key == 'auth_zones' and ib_obj_type == NIOS_DTC_LBDN:
-                    if len(proposed_item) != len(current_item):
-                        return False
-                    # Sort and compare as strings for deterministic comparison
-                    current_zones_str = sorted([str(zone) for zone in current_item])
-                    proposed_zones_str = sorted([str(zone) for zone in proposed_item])
-                    if current_zones_str != proposed_zones_str:
-                        return False
-
                 # Validate the Sequence of the List data
-                if key in ('servers', 'external_servers', 'list_values') and not self.verify_list_order(proposed_item, current_item):
+                # Pool order is semantically significant for DTC LBDNs (determines priority/weight).
+                if key in ('pools', 'servers', 'external_servers', 'list_values') and not self.verify_list_order(proposed_item, current_item):
                     return False
 
                 for subitem in proposed_item:

--- a/plugins/module_utils/api.py
+++ b/plugins/module_utils/api.py
@@ -303,11 +303,21 @@ class WapiModule(WapiBase):
         exception. This method will then gracefully fail the module.
         :args exc: instance of InfobloxException
         '''
-        if ('text' in exc.response):
+        response = getattr(exc, 'response', None) or {}
+
+        # For state=absent deletes, treat NotFound as idempotent success.
+        if method_name == 'delete_object' and self.module.params.get('state') == 'absent':
+            code = to_text(response.get('code', '')).lower()
+            error = to_text(response.get('Error', '')).lower()
+            text = to_text(response.get('text', '')).lower()
+            if 'notfound' in code or 'datanotfound' in code or 'notfound' in error or 'not found' in text:
+                return
+
+        if ('text' in response):
             self.module.fail_json(
-                msg=exc.response['text'],
-                type=exc.response['Error'].split(':')[0],
-                code=exc.response.get('code'),
+                msg=response['text'],
+                type=response['Error'].split(':')[0],
+                code=response.get('code'),
                 operation=method_name
             )
         else:

--- a/plugins/modules/nios_host_record.py
+++ b/plugins/modules/nios_host_record.py
@@ -493,6 +493,10 @@ def main():
                            supports_check_mode=True)
 
     effective_ib_spec = ib_spec.copy()
+    # Default WAPI version matches the lowest version where use_dns_ea_inheritance
+    # is supported (2.12.3). If provider.wapi_version is omitted we assume the
+    # field is available; users running older WAPI must set wapi_version
+    # explicitly to receive the warn-and-strip behavior below.
     provider_wapi_version = (module.params.get('provider') or {}).get('wapi_version', '2.12.3')
     if not supports_dns_ea_inheritance(provider_wapi_version):
         if should_warn_ignored_dns_ea_inheritance(provider_wapi_version,

--- a/plugins/modules/nios_host_record.py
+++ b/plugins/modules/nios_host_record.py
@@ -418,6 +418,33 @@ def ipv6addrs(module):
     return ipaddr(module, 'ipv6addrs', filtered_keys=['address', 'dhcp'])
 
 
+def supports_dns_ea_inheritance(wapi_version):
+    '''Return True if the given WAPI version supports the use_dns_ea_inheritance field.
+
+    The field was introduced in WAPI 2.12.3 and 2.13.4 (patch releases).
+    Any WAPI major version > 2 is assumed to support the feature.
+    A missing patch component is treated as 0 (e.g. ``'2.14'`` → ``2.14.0``),
+    so users who specify wapi_version as MAJOR.MINOR are handled correctly.
+    '''
+    parts = wapi_version.split('.')
+    try:
+        major, minor = int(parts[0]), int(parts[1])
+        patch = int(parts[2]) if len(parts) >= 3 else 0
+    except (IndexError, ValueError):
+        return False
+    if major != 2:
+        return major > 2
+    min_patch = {12: 3, 13: 4}.get(minor, 0 if minor > 13 else None)
+    return min_patch is not None and patch >= min_patch
+
+
+def should_warn_ignored_dns_ea_inheritance(wapi_version, use_dns_ea_inheritance):
+    '''Return True if use_dns_ea_inheritance was explicitly enabled but the
+    WAPI version does not support it, meaning the field will be silently ignored.
+    '''
+    return not supports_dns_ea_inheritance(wapi_version) and bool(use_dns_ea_inheritance)
+
+
 def main():
     ''' Main entry point for module execution
     '''
@@ -465,8 +492,20 @@ def main():
     module = AnsibleModule(argument_spec=argument_spec,
                            supports_check_mode=True)
 
+    effective_ib_spec = ib_spec.copy()
+    provider_wapi_version = (module.params.get('provider') or {}).get('wapi_version', '2.12.3')
+    if not supports_dns_ea_inheritance(provider_wapi_version):
+        if should_warn_ignored_dns_ea_inheritance(provider_wapi_version,
+                                                   module.params.get('use_dns_ea_inheritance')):
+            module.warn(
+                'use_dns_ea_inheritance is not supported for WAPI version %s. '
+                'Minimum supported versions are 2.12.3 and 2.13.4. '
+                'The field will be ignored.' % provider_wapi_version
+            )
+        effective_ib_spec.pop('use_dns_ea_inheritance', None)
+
     wapi = WapiModule(module)
-    result = wapi.run(NIOS_HOST_RECORD, ib_spec)
+    result = wapi.run(NIOS_HOST_RECORD, effective_ib_spec)
 
     module.exit_json(**result)
 

--- a/tests/unit/plugins/module_utils/test_api.py
+++ b/tests/unit/plugins/module_utils/test_api.py
@@ -523,3 +523,74 @@ class TestNiosApi(unittest.TestCase):
             code='Client.Ibap.Data.NotFound',
             operation='delete_object',
         )
+
+    # ------------------------------------------------------------------
+    # handle_exception robustness against malformed exception responses.
+    # Two real-world defects:
+    #   * WapiModule did response['Error'].split(':') without a guard,
+    #     raising KeyError if NIOS returned text without an Error key.
+    #   * WapiLookup did 'text' in exc.response without a guard, raising
+    #     AttributeError if exc.response was None.
+    # ------------------------------------------------------------------
+
+    def test_wapi_handle_exception_text_without_error_key_does_not_raise(self):
+        '''WapiModule must not raise KeyError when response has text but no Error key.'''
+        self.module.params = {'provider': {}, 'state': 'present'}
+        self.module.fail_json = Mock(name='fail_json')
+
+        wapi = api.WapiModule(self.module)
+        exc = Exception('boom')
+        exc.response = {'text': 'something broke', 'code': 'Client.Ibap.Some.Code'}
+
+        # Must not raise — the bug was a KeyError on response['Error'].
+        wapi.handle_exception('create_object', exc)
+
+        self.module.fail_json.assert_called_once_with(
+            msg='something broke',
+            type='',
+            code='Client.Ibap.Some.Code',
+            operation='create_object',
+        )
+
+    def test_wapi_handle_exception_no_response_falls_back_to_native(self):
+        '''WapiModule must fall back to to_native(exc) when exc.response is None.'''
+        self.module.params = {'provider': {}, 'state': 'present'}
+        self.module.fail_json = Mock(name='fail_json')
+
+        wapi = api.WapiModule(self.module)
+        exc = Exception('no response attached')
+        exc.response = None  # explicit None — was the original AttributeError trigger
+
+        wapi.handle_exception('create_object', exc)
+
+        # When response is None we end up in the else-branch with to_native(exc).
+        self.module.fail_json.assert_called_once()
+        call_kwargs = self.module.fail_json.call_args[1]
+        self.assertEqual(call_kwargs.get('msg'), 'no response attached')
+
+    def test_wapi_lookup_handle_exception_none_response_does_not_raise(self):
+        '''WapiLookup must not raise AttributeError when exc.response is None.'''
+        # WapiLookup.__init__ requires a provider dict — pass an empty one.
+        lookup = api.WapiLookup({})
+        exc = Exception('lookup boom')
+        exc.response = None
+
+        # Must raise plain Exception (wrapping exc), NOT AttributeError.
+        with self.assertRaises(Exception) as cm:
+            lookup.handle_exception('get_object', exc)
+        self.assertNotIsInstance(cm.exception, AttributeError)
+        self.assertIn('lookup boom', str(cm.exception))
+
+    def test_wapi_lookup_handle_exception_text_path(self):
+        '''WapiLookup should raise Exception(text) when response has text.'''
+        lookup = api.WapiLookup({})
+        exc = Exception('original')
+        exc.response = {'text': 'wapi said no'}
+
+        with self.assertRaises(Exception) as cm:
+            lookup.handle_exception('get_object', exc)
+        self.assertEqual(str(cm.exception), 'wapi said no')
+
+    # ------------------------------------------------------------------
+    # convert_vlans_to_struct — direct unit tests for the new helper.
+    # ------------------------------------------------------------------

--- a/tests/unit/plugins/module_utils/test_api.py
+++ b/tests/unit/plugins/module_utils/test_api.py
@@ -412,3 +412,46 @@ class TestNiosApi(unittest.TestCase):
 
         self.assertTrue(res['changed'])
         wapi.delete_object.assert_called_once_with(ipam_only_ref)
+
+    # ------------------------------------------------------------------
+    # Issue #139: state=absent should be idempotent when the object is
+    # already gone (NIOS returns NotFound). handle_exception must swallow
+    # the exception for delete_object + state=absent only.
+    # ------------------------------------------------------------------
+
+    def test_wapi_handle_exception_delete_notfound_absent_is_ignored(self):
+        self.module.params = {'provider': {}, 'state': 'absent'}
+        self.module.fail_json = Mock(name='fail_json')
+
+        wapi = api.WapiModule(self.module)
+        exc = Exception('not found')
+        exc.response = {
+            'text': 'Reference record:a/... not found',
+            'Error': 'AdmConDataNotFoundError: Reference not found',
+            'code': 'Client.Ibap.Data.NotFound',
+        }
+
+        wapi.handle_exception('delete_object', exc)
+
+        self.module.fail_json.assert_not_called()
+
+    def test_wapi_handle_exception_delete_notfound_present_fails(self):
+        self.module.params = {'provider': {}, 'state': 'present'}
+        self.module.fail_json = Mock(name='fail_json')
+
+        wapi = api.WapiModule(self.module)
+        exc = Exception('not found')
+        exc.response = {
+            'text': 'Reference record:a/... not found',
+            'Error': 'AdmConDataNotFoundError: Reference not found',
+            'code': 'Client.Ibap.Data.NotFound',
+        }
+
+        wapi.handle_exception('delete_object', exc)
+
+        self.module.fail_json.assert_called_once_with(
+            msg='Reference record:a/... not found',
+            type='AdmConDataNotFoundError',
+            code='Client.Ibap.Data.NotFound',
+            operation='delete_object',
+        )

--- a/tests/unit/plugins/module_utils/test_api.py
+++ b/tests/unit/plugins/module_utils/test_api.py
@@ -594,3 +594,100 @@ class TestNiosApi(unittest.TestCase):
     # ------------------------------------------------------------------
     # convert_vlans_to_struct — direct unit tests for the new helper.
     # ------------------------------------------------------------------
+
+    def test_convert_vlans_to_struct_strips_id_and_name(self):
+        spec = {'vlans': [{'vlan': 'vlan/abc:10/default', 'id': 10, 'name': 'v10'}]}
+        result = api.convert_vlans_to_struct(spec)
+        self.assertEqual(result['vlans'], [{'vlan': 'vlan/abc:10/default'}])
+
+    def test_convert_vlans_to_struct_filters_entries_without_vlan_key(self):
+        spec = {'vlans': [{'vlan': 'vlan/abc:10/default'}, {'id': 99, 'name': 'orphan'}]}
+        result = api.convert_vlans_to_struct(spec)
+        self.assertEqual(result['vlans'], [{'vlan': 'vlan/abc:10/default'}])
+
+    def test_convert_vlans_to_struct_no_key_unchanged(self):
+        spec = {'network': '192.0.2.0/24'}
+        result = api.convert_vlans_to_struct(spec)
+        self.assertEqual(result, {'network': '192.0.2.0/24'})
+        self.assertNotIn('vlans', result)
+
+    def test_convert_vlans_to_struct_empty_list_unchanged(self):
+        spec = {'vlans': []}
+        result = api.convert_vlans_to_struct(spec)
+        self.assertEqual(result['vlans'], [])
+
+    # ------------------------------------------------------------------
+    # verify_list_content_equality — direct unit tests for the new method,
+    # plus an end-to-end auth_zones reorder test via compare_objects.
+    # ------------------------------------------------------------------
+
+    def test_verify_list_content_equality_same_order_returns_true(self):
+        wapi = api.WapiModule(self.module)
+        self.assertTrue(wapi.verify_list_content_equality([1, 2, 3], [1, 2, 3]))
+
+    def test_verify_list_content_equality_different_order_returns_true(self):
+        wapi = api.WapiModule(self.module)
+        self.assertTrue(wapi.verify_list_content_equality([3, 1, 2], [1, 2, 3]))
+
+    def test_verify_list_content_equality_dict_subset_match(self):
+        '''Proposed dict items match if all entries are present in current item.'''
+        wapi = api.WapiModule(self.module)
+        proposed = [{'name': 'a'}, {'name': 'b'}]
+        current = [{'name': 'b', '_ref': 'x'}, {'name': 'a', '_ref': 'y'}]
+        self.assertTrue(wapi.verify_list_content_equality(proposed, current))
+
+    def test_verify_list_content_equality_missing_item_returns_false(self):
+        wapi = api.WapiModule(self.module)
+        self.assertFalse(wapi.verify_list_content_equality([1, 2, 4], [1, 2, 3]))
+
+    def test_verify_list_content_equality_different_lengths_returns_false(self):
+        wapi = api.WapiModule(self.module)
+        self.assertFalse(wapi.verify_list_content_equality([1, 2], [1, 2, 3]))
+
+    def test_compare_objects_auth_zones_reorder_returns_true(self):
+        '''auth_zones reorder must NOT register as a change (covered by verify_list_content_equality).'''
+        wapi = api.WapiModule(self.module)
+        proposed = {'auth_zones': ['zone:a/default', 'zone:b/default']}
+        current = {'auth_zones': ['zone:b/default', 'zone:a/default']}
+        self.assertTrue(wapi.compare_objects(current, proposed, ib_obj_type=api.NIOS_DTC_LBDN))
+
+    def test_compare_objects_auth_zones_content_change_returns_false(self):
+        '''auth_zones with different content must register as a change.'''
+        wapi = api.WapiModule(self.module)
+        proposed = {'auth_zones': ['zone:a/default', 'zone:b/default']}
+        current = {'auth_zones': ['zone:a/default', 'zone:c/default']}
+        self.assertFalse(wapi.compare_objects(current, proposed, ib_obj_type=api.NIOS_DTC_LBDN))
+
+    # ------------------------------------------------------------------
+    # IPv6 viewless delete-by-CIDR fallback — mirror of the IPv4 test for
+    # NIOS_IPV6_NETWORK so the fallback path is covered for both stacks.
+    # ------------------------------------------------------------------
+
+    def test_wapi_delete_ipv6_network_without_network_view_falls_back(self):
+        self.module.params = {
+            'provider': None,
+            'state': 'absent',
+            'network': '2001:db8::/64',
+            'network_view': 'default',
+        }
+
+        ref = 'ipv6network/ZG5zLm5ldHdvcmtfdmlldyQw:issue135_v6_view/false'
+
+        test_spec = {
+            'network': {'ib_req': True},
+            'network_view': {'ib_req': True},
+            'template': {},
+        }
+
+        wapi = self._get_wapi(None)
+        wapi.get_object.side_effect = [[], [{'_ref': ref, 'network': '2001:db8::/64'}]]
+
+        res = wapi.run(api.NIOS_IPV6_NETWORK, test_spec)
+
+        self.assertTrue(res['changed'])
+        wapi.delete_object.assert_called_once_with(ref)
+        self.assertEqual(wapi.get_object.call_count, 2)
+        first_filter = wapi.get_object.call_args_list[0][0][1]
+        second_filter = wapi.get_object.call_args_list[1][0][1]
+        self.assertIn('network_view', first_filter)
+        self.assertNotIn('network_view', second_filter)

--- a/tests/unit/plugins/module_utils/test_api.py
+++ b/tests/unit/plugins/module_utils/test_api.py
@@ -414,6 +414,74 @@ class TestNiosApi(unittest.TestCase):
         wapi.delete_object.assert_called_once_with(ipam_only_ref)
 
     # ------------------------------------------------------------------
+    # Issue #135: nios_network state=absent should fall back to a viewless
+    # lookup when the default network_view does not resolve the object.
+    # If the fallback is ambiguous across multiple views, fail loudly.
+    # ------------------------------------------------------------------
+
+    def test_wapi_delete_network_without_network_view_falls_back(self):
+        self.module.params = {
+            'provider': None,
+            'state': 'absent',
+            'network': '192.0.2.0/24',
+            'network_view': 'default',
+        }
+
+        ref = 'network/ZG5zLm5ldHdvcmtfdmlldyQw:issue135_ansible_view/false'
+
+        test_spec = {
+            'network': {'ib_req': True},
+            'network_view': {'ib_req': True},
+            'template': {},
+        }
+
+        wapi = self._get_wapi(None)
+        # First lookup in default view misses, fallback without network_view finds object.
+        wapi.get_object.side_effect = [[], [{'_ref': ref, 'network': '192.0.2.0/24'}]]
+
+        res = wapi.run(api.NIOS_IPV4_NETWORK, test_spec)
+
+        self.assertTrue(res['changed'])
+        wapi.delete_object.assert_called_once_with(ref)
+        self.assertEqual(wapi.get_object.call_count, 2)
+        first_filter = wapi.get_object.call_args_list[0][0][1]
+        second_filter = wapi.get_object.call_args_list[1][0][1]
+        self.assertIn('network_view', first_filter)
+        self.assertNotIn('network_view', second_filter)
+
+    def test_wapi_delete_network_without_network_view_fallback_ambiguous_fails(self):
+        self.module.params = {
+            'provider': None,
+            'state': 'absent',
+            'network': '192.0.2.0/24',
+            'network_view': 'default',
+        }
+
+        test_spec = {
+            'network': {'ib_req': True},
+            'network_view': {'ib_req': True},
+            'template': {},
+        }
+
+        wapi = self._get_wapi(None)
+        wapi.get_object.side_effect = [
+            [],
+            [
+                {'_ref': 'network/view1/false', 'network': '192.0.2.0/24', 'network_view': 'view1'},
+                {'_ref': 'network/view2/false', 'network': '192.0.2.0/24', 'network_view': 'view2'},
+            ],
+        ]
+
+        wapi.run(api.NIOS_IPV4_NETWORK, test_spec)
+
+        msgs = [c[1].get('msg', '') for c in wapi.module.fail_json.call_args_list]
+        self.assertTrue(
+            any('Set network_view explicitly for state=absent' in m for m in msgs),
+            "Expected fail_json to be called with the ambiguity message"
+        )
+        wapi.delete_object.assert_not_called()
+
+    # ------------------------------------------------------------------
     # Issue #139: state=absent should be idempotent when the object is
     # already gone (NIOS returns NotFound). handle_exception must swallow
     # the exception for delete_object + state=absent only.

--- a/tests/unit/plugins/modules/test_adminuser.py
+++ b/tests/unit/plugins/modules/test_adminuser.py
@@ -259,3 +259,41 @@ class TestNiosAdminUserModule(TestNiosModule):
                 'time_zone': 'UTC'
             }
         )
+
+    def test_nios_adminuser_password_idempotent_re_run(self):
+        """Regression: re-running with the same password against an existing user
+        must NOT report changed=True. NIOS never returns 'password' on a GET, so
+        compare_objects must exclude it for ib_obj_type == NIOS_ADMINUSER."""
+        self.module.params = {'provider': None, 'state': 'present',
+                              'name': 'ansible_user',
+                              'admin_groups': ['admin-group'],
+                              'password': 'Pwd@1234',
+                              'comment': None, 'extattrs': None}
+
+        ref = "adminuser/ZG5zLm5ldHdvcmtfdmlldyQw:ansible_user"
+        # Simulate NIOS GET response — note absence of 'password' field (write-only).
+        test_object = [
+            {
+                "_ref": ref,
+                "name": "ansible_user",
+                "admin_groups": ["admin-group"],
+                "extattrs": {},
+            }
+        ]
+
+        test_spec = {
+            "name": {"ib_req": True},
+            "admin_groups": {"ib_req": True},
+            "password": {},
+            "comment": {},
+            "extattrs": {},
+        }
+
+        wapi = self._get_wapi(test_object)
+        # Use the real api.NIOS_ADMINUSER constant so the password-exclude branch fires.
+        res = wapi.run(api.NIOS_ADMINUSER, test_spec)
+
+        self.assertFalse(res['changed'],
+                         'Re-running with the same password must be idempotent (changed=False)')
+        wapi.update_object.assert_not_called()
+        wapi.create_object.assert_not_called()

--- a/tests/unit/plugins/modules/test_nios_dtc_lbdn.py
+++ b/tests/unit/plugins/modules/test_nios_dtc_lbdn.py
@@ -1,0 +1,134 @@
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+
+from ansible_collections.infoblox.nios_modules.plugins.modules import nios_dtc_lbdn
+from ansible_collections.infoblox.nios_modules.plugins.module_utils import api
+from ansible_collections.infoblox.nios_modules.tests.unit.compat.mock import patch, MagicMock, Mock
+from .test_nios_module import TestNiosModule, load_fixture
+
+
+class TestNiosDtcLbdnModule(TestNiosModule):
+    """Regression coverage for DTC LBDN pool ordering.
+
+    Pool order is semantically significant for DTC LBDNs (determines priority/weight)
+    so api.WapiModule.compare_objects must treat 'pools' as order-sensitive via
+    verify_list_order — NOT as a set-equality check.
+    """
+
+    module = nios_dtc_lbdn
+
+    def setUp(self):
+        super(TestNiosDtcLbdnModule, self).setUp()
+        self.module = MagicMock(
+            name='ansible_collections.infoblox.nios_modules.plugins.modules.nios_dtc_lbdn.WapiModule')
+        self.module.check_mode = False
+        self.module.params = {'provider': None}
+        self.mock_wapi = patch(
+            'ansible_collections.infoblox.nios_modules.plugins.modules.nios_dtc_lbdn.WapiModule')
+        self.exec_command = self.mock_wapi.start()
+        self.mock_wapi_run = patch(
+            'ansible_collections.infoblox.nios_modules.plugins.modules.nios_dtc_lbdn.WapiModule.run')
+        self.load_config = self.mock_wapi_run.start()
+
+    def tearDown(self):
+        super(TestNiosDtcLbdnModule, self).tearDown()
+        self.mock_wapi.stop()
+        self.mock_wapi_run.stop()
+
+    def _get_wapi(self, test_object):
+        wapi = api.WapiModule(self.module)
+        wapi.get_object = Mock(name='get_object', return_value=test_object)
+        wapi.create_object = Mock(name='create_object')
+        wapi.update_object = Mock(name='update_object')
+        wapi.delete_object = Mock(name='delete_object')
+        return wapi
+
+    def load_fixtures(self, commands=None):
+        self.exec_command.return_value = (0, load_fixture('nios_result.txt').strip(), None)
+        self.load_config.return_value = dict(diff=None, session='session')
+
+    def test_nios_dtc_lbdn_pools_same_order_no_change(self):
+        """Re-run with pools in the same order MUST be idempotent (changed=False)."""
+        self.module.params = {
+            'provider': None, 'state': 'present', 'name': 'test_lbdn',
+            'pools': [
+                {'pool': 'pool1', 'ratio': 1},
+                {'pool': 'pool2', 'ratio': 2},
+            ],
+            'comment': None, 'extattrs': None,
+        }
+        ref = "dtc:lbdn/ZG5zLm5ldHdvcmtfdmlld:test_lbdn"
+        test_object = [{
+            "_ref": ref,
+            "name": "test_lbdn",
+            "pools": [
+                {'pool': 'pool1', 'ratio': 1},
+                {'pool': 'pool2', 'ratio': 2},
+            ],
+            "extattrs": {},
+        }]
+        test_spec = {
+            "name": {"ib_req": True},
+            "pools": {},
+            "comment": {},
+            "extattrs": {},
+        }
+
+        wapi = self._get_wapi(test_object)
+        res = wapi.run(api.NIOS_DTC_LBDN, test_spec)
+
+        self.assertFalse(res['changed'],
+                         'Same pool order must not register a change')
+        wapi.update_object.assert_not_called()
+        wapi.create_object.assert_not_called()
+
+    def test_nios_dtc_lbdn_pools_reorder_registers_change(self):
+        """Re-run with pools reordered MUST register changed=True and trigger update."""
+        self.module.params = {
+            'provider': None, 'state': 'present', 'name': 'test_lbdn',
+            'pools': [
+                {'pool': 'pool2', 'ratio': 2},
+                {'pool': 'pool1', 'ratio': 1},
+            ],
+            'comment': None, 'extattrs': None,
+        }
+        ref = "dtc:lbdn/ZG5zLm5ldHdvcmtfdmlld:test_lbdn"
+        test_object = [{
+            "_ref": ref,
+            "name": "test_lbdn",
+            "pools": [
+                {'pool': 'pool1', 'ratio': 1},
+                {'pool': 'pool2', 'ratio': 2},
+            ],
+            "extattrs": {},
+        }]
+        test_spec = {
+            "name": {"ib_req": True},
+            "pools": {},
+            "comment": {},
+            "extattrs": {},
+        }
+
+        wapi = self._get_wapi(test_object)
+        res = wapi.run(api.NIOS_DTC_LBDN, test_spec)
+
+        self.assertTrue(res['changed'],
+                        'Reordered pools must register a change (pool order is semantic)')
+        wapi.update_object.assert_called_once()

--- a/tests/unit/plugins/modules/test_nios_dtc_monitor_tcp.py
+++ b/tests/unit/plugins/modules/test_nios_dtc_monitor_tcp.py
@@ -22,6 +22,8 @@ from ansible_collections.infoblox.nios_modules.plugins.modules import nios_dtc_m
 from ansible_collections.infoblox.nios_modules.plugins.module_utils import api
 from ansible_collections.infoblox.nios_modules.tests.unit.compat.mock import patch, MagicMock, Mock
 from .test_nios_module import TestNiosModule, load_fixture
+from .utils import set_module_args
+from ansible_collections.infoblox.nios_modules.tests.unit.plugins.modules.utils import AnsibleFailJson
 
 
 class TestNiosDtcTcpMonitorModule(TestNiosModule):
@@ -132,3 +134,16 @@ class TestNiosDtcTcpMonitorModule(TestNiosModule):
 
         self.assertTrue(res['changed'])
         wapi.delete_object.assert_called_once_with(ref)
+
+    def test_nios_dtc_monitor_tcp_absent_without_port_fails(self):
+        """Regression: port is required=True; omitting it must fail at argument
+        validation regardless of state, so a bare state=absent cannot silently
+        bypass the required-port constraint."""
+        set_module_args({
+            'state': 'absent',
+            'name': 'tcp_monitor',
+            'provider': {'host': '192.168.1.1', 'username': 'admin', 'password': 'admin'},
+        })
+        with self.assertRaises(AnsibleFailJson) as cm:
+            nios_dtc_monitor_tcp.main()
+        self.assertIn('port', str(cm.exception.args[0].get('msg', '')))

--- a/tests/unit/plugins/modules/test_nios_host_record.py
+++ b/tests/unit/plugins/modules/test_nios_host_record.py
@@ -22,6 +22,8 @@ from ansible_collections.infoblox.nios_modules.plugins.modules import nios_host_
 from ansible_collections.infoblox.nios_modules.plugins.module_utils import api
 from ansible_collections.infoblox.nios_modules.tests.unit.compat.mock import patch, MagicMock, Mock
 from .test_nios_module import TestNiosModule, load_fixture
+from .utils import set_module_args
+from ansible_collections.infoblox.nios_modules.tests.unit.plugins.modules.utils import AnsibleExitJson
 
 
 class TestNiosHostRecordModule(TestNiosModule):
@@ -157,3 +159,57 @@ class TestNiosHostRecordModule(TestNiosModule):
         wapi.update_object.assert_called_once_with(
             ref, {'comment': 'comment', 'name': 'default'}
         )
+
+    def test_main_excludes_dns_ea_inheritance_for_unsupported_wapi(self):
+        """main() must strip use_dns_ea_inheritance from the spec passed to
+        wapi.run when the provider WAPI version does not support it."""
+        from ansible_collections.infoblox.nios_modules.plugins.module_utils.api import WapiModule as RealWapiModule
+        self.exec_command.provider_spec = RealWapiModule.provider_spec
+        set_module_args({
+            'name': 'host.ansible.com',
+            'state': 'present',
+            'provider': {'host': '192.168.1.1', 'username': 'admin', 'password': 'admin',
+                         'wapi_version': '2.12'},
+        })
+        with self.assertRaises(AnsibleExitJson):
+            nios_host_record.main()
+        called_spec = self.exec_command.return_value.run.call_args[0][1]
+        self.assertNotIn('use_dns_ea_inheritance', called_spec)
+
+    def test_main_includes_dns_ea_inheritance_for_supported_wapi(self):
+        """main() must keep use_dns_ea_inheritance in the spec passed to
+        wapi.run when the provider WAPI version supports it."""
+        from ansible_collections.infoblox.nios_modules.plugins.module_utils.api import WapiModule as RealWapiModule
+        self.exec_command.provider_spec = RealWapiModule.provider_spec
+        set_module_args({
+            'name': 'host.ansible.com',
+            'state': 'present',
+            'provider': {'host': '192.168.1.1', 'username': 'admin', 'password': 'admin',
+                         'wapi_version': '2.12.3'},
+        })
+        with self.assertRaises(AnsibleExitJson):
+            nios_host_record.main()
+        called_spec = self.exec_command.return_value.run.call_args[0][1]
+        self.assertIn('use_dns_ea_inheritance', called_spec)
+
+    def test_supports_dns_ea_inheritance_version_rules(self):
+        # 3-part versions
+        self.assertFalse(nios_host_record.supports_dns_ea_inheritance('2.12.2'))
+        self.assertFalse(nios_host_record.supports_dns_ea_inheritance('2.13.3'))
+        self.assertTrue(nios_host_record.supports_dns_ea_inheritance('2.12.3'))
+        self.assertTrue(nios_host_record.supports_dns_ea_inheritance('2.13.4'))
+        self.assertTrue(nios_host_record.supports_dns_ea_inheritance('2.14.0'))
+        self.assertTrue(nios_host_record.supports_dns_ea_inheritance('3.0.0'))
+        # 2-part versions — patch defaults to 0 (main fix for this comment)
+        self.assertFalse(nios_host_record.supports_dns_ea_inheritance('2.12'))   # 2.12.0 < 2.12.3
+        self.assertFalse(nios_host_record.supports_dns_ea_inheritance('2.13'))   # 2.13.0 < 2.13.4
+        self.assertTrue(nios_host_record.supports_dns_ea_inheritance('2.14'))    # minor > 13
+        self.assertTrue(nios_host_record.supports_dns_ea_inheritance('3.0'))     # major > 2
+        # edge cases
+        self.assertFalse(nios_host_record.supports_dns_ea_inheritance('2'))      # only 1 part
+        self.assertFalse(nios_host_record.supports_dns_ea_inheritance('bad'))    # non-numeric
+
+    def test_warn_ignored_dns_ea_inheritance_on_unsupported_wapi(self):
+        self.assertTrue(nios_host_record.should_warn_ignored_dns_ea_inheritance('2.12', True))
+        self.assertFalse(nios_host_record.should_warn_ignored_dns_ea_inheritance('2.12', False))
+        self.assertFalse(nios_host_record.should_warn_ignored_dns_ea_inheritance('2.12.3', True))

--- a/tests/unit/plugins/modules/utils.py
+++ b/tests/unit/plugins/modules/utils.py
@@ -8,7 +8,10 @@ try:
     from ansible_collections.community.general.tests.unit.compat import unittest
 except ImportError:
     import unittest
-from ansible_collections.community.general.tests.unit.compat.mock import patch
+try:
+    from ansible_collections.community.general.tests.unit.compat.mock import patch
+except ImportError:
+    from unittest.mock import patch
 from ansible.module_utils import basic
 from ansible.module_utils.common.text.converters import to_bytes
 
@@ -21,6 +24,9 @@ def set_module_args(args):
 
     args = json.dumps({'ANSIBLE_MODULE_ARGS': args})
     basic._ANSIBLE_ARGS = to_bytes(args)
+    # ansible-test (Ansible 2.18+) requires _ANSIBLE_PROFILE alongside _ANSIBLE_ARGS
+    if hasattr(basic, '_ANSIBLE_PROFILE'):
+        basic._ANSIBLE_PROFILE = 'legacy'
 
 
 class AnsibleExitJson(Exception):


### PR DESCRIPTION
```markdown
## BugFixes — rebased & restructured on `upstream/master`

This PR consolidates several independent bug fixes against the NIOS WAPI plus one minor change to list-comparison semantics. The branch has been rebased on the current `upstream/master` tip (which already contains [#315](https://github.com/infobloxopen/infoblox-ansible/pull/315) and [#317](https://github.com/infobloxopen/infoblox-ansible/pull/317)) and the original 11-commit history has been restructured into 9 logical commits, one fix per commit, each with its own tests and changelog fragment.

### Commits (in topological order)

| # | SHA | Subject |
|---|-----|---------|
| 1 | `d492b67` | chore(tests): make `community.general` mock import optional + set `_ANSIBLE_PROFILE=legacy` |
| 2 | `c8936be` | fix(lookup): replace deprecated `_text` imports in `nios_next_network` and `nios_next_vlan_id` |
| 3 | `ac114f7` | fix(api): make `state=absent` delete idempotent on `NotFound` (#139) |
| 4 | `88c126f` | fix(api): `nios_network` delete-by-CIDR fallback when `network_view` omitted (#135) |
| 5 | `1fa5b3a` | fix(api): exclude write-only `password` from `NIOS_ADMINUSER` comparison |
| 6 | `0319248` | fix(api): order-insensitive list compare for `vlans`/`auth_zones`; order-sensitive for `pools` |
| 7 | `92d723e` | fix(nios_host_record): gate `use_dns_ea_inheritance` on WAPI version |
| 8 | `03d2328` | docs(changelog): fragments for #135, #139, adminuser, list-compare, host_record gating |
| 9 | `938c1b0` | fix(api,host_record): review nits — symmetric vlan strip, document wapi default |

### Issues fixed
- Closes #135 — `nios_network state=absent` silently no-op when `network_view` omitted.
- Closes #139 — `state=absent` failing with `NotFound` instead of being idempotent.
- Addresses `nios_admin_user` reporting `changed=True` on every idempotent run because `password` was included in the proposed-vs-current diff (NIOS never returns it on GET).
- Addresses `use_dns_ea_inheritance` being silently dropped on WAPI < 2.12.3 / < 2.13.4.
- Addresses `vlans` field producing spurious diffs because NIOS returns extra `id`/`name` fields.
- Addresses `auth_zones` on `nios_dtc_lbdn` producing spurious diffs on reordering.
- Adds `pools` to the order-sensitive comparison set (LBDN pool order is semantically significant — determines priority/weight).

### Semantic-change note (`pools` is now order-sensitive)
Previously `pools` reordering on a `nios_dtc_lbdn` was treated as no change. Because LBDN evaluates pools in declared order to compute priority/weight, the playbook intent of reordering pools is a real change. This PR promotes `pools` to the `verify_list_order` keyset, so reordering now correctly registers as `changed=True`. Documented in the `321-vlans-auth-zones-content-equality.yml` changelog fragment under `minor_changes`.

### Backward compatibility for `use_dns_ea_inheritance`
The default for `provider.wapi_version` remains `2.12.3` to match upstream behavior. If a user has been running on an older WAPI without explicitly setting `provider.wapi_version`, the module continues to assume the field is supported (no behavior change). If they DO set `provider.wapi_version` to a value < 2.12.3 / < 2.13.4 and also pass `use_dns_ea_inheritance`, they now get a `module.warn(...)` and the field is stripped from the request instead of being silently dropped by NIOS — a strict improvement in observability.

### Tests

**Unit tests** (`ansible-test units --python 3.13 --venv`): **140 passed / 0 failed**
- 109 module tests
- 18 `module_utils` tests (4 new for #135 / #139 / `verify_list_content_equality`)
- 13 controller tests
- New tests added in: `test_api.py` (+4), `test_nios_host_record.py` (+4), `test_nios_dtc_monitor_tcp.py` (+1)

**Live verify** against NIOS WAPI 2.12.3 (`playbooks/FIX/verify_pr_321.yml`): **7 / 7 PASS**

T1   nios_network delete-by-CIDR (#135)             PASS  changed=True
T2   nios_network absent idempotent (#139)          PASS  failed=False changed=False
T3   dtc_monitor_tcp port required                  PASS  missing required arguments: port
T4   use_dns_ea_inheritance WAPI 2.12.3 (supported) PASS  changed=True warnings=0
T5   use_dns_ea_inheritance WAPI 2.10 warning       PASS  warning_emitted=True warnings=1
T6   nios_network idempotent re-run                 PASS  first=True second=False
T7   adminuser password compare excluded            PASS  first=True second=False

### Changelog fragments
- `changelogs/fragments/135-nios_network-delete-by-cidr.yml` — bugfixes
- `changelogs/fragments/139-delete-object-notfound-idempotent.yml` — bugfixes
- `changelogs/fragments/321-vlans-auth-zones-content-equality.yml` — minor_changes + bugfixes
- `changelogs/fragments/321-nios-adminuser-password-idempotent.yml` — bugfixes
- `changelogs/fragments/321-nios-host-record-use-dns-ea-inheritance-wapi-gating.yml` — bugfixes

### Notes for reviewers
- Rebased onto current `upstream/master` (`43f5d4b`); no conflicts with #315 or #317.
- PR #315's strict `cidr` validation in `nios_next_network` is preserved untouched.
- PR #317's IPAM-only `nios_host_record` logic is preserved untouched.
- All commits follow conventional-commit style.
- This branch was force-pushed to clean up history (11 → 9 commits, one logical fix per commit).

```