### PR TITLE
fix(issue-221): strip use_option for structural DHCP options router/3…

### DIFF
--- a/changelogs/fragments/221-strip-use-option-for-structural-dhcp-options.yaml
+++ b/changelogs/fragments/221-strip-use-option-for-structural-dhcp-options.yaml
@@ -1,0 +1,9 @@
+---
+bugfixes:
+  - |
+    nios_network, nios_range - structural DHCP options (router/3,
+    ntp-servers/42, subnet-mask/1) no longer cause "Option X can not have a
+    use_option flag" WAPI errors. The ``check_vendor_specific_dhcp_option``
+    helper now strips ``use_option`` for these option numbers as well as when
+    options are specified by name (e.g. ``name: router``) rather than by
+    number (fixes https://github.com/infobloxopen/infoblox-ansible/issues/221).

--- a/plugins/modules/nios_network.py
+++ b/plugins/modules/nios_network.py
@@ -367,8 +367,8 @@ def check_ip_addr_type(obj_filter, ib_spec):
 
 
 def check_vendor_specific_dhcp_option(module, ib_spec):
-    '''This function will check if the argument dhcp option belongs to vendor-specific and if yes then will remove
-     use_options flag which is not supported with vendor-specific dhcp options.
+    '''Remove unsupported `use_option` from DHCP options (vendor-specific and structural).
+     WAPI rejects `use_option` for some option numbers/names.
     '''
     # DHCP option numbers and names that WAPI rejects when use_option is present.
     # Includes classic vendor-specific options (43, 60, 67, 124, 125) and

--- a/plugins/modules/nios_network.py
+++ b/plugins/modules/nios_network.py
@@ -370,12 +370,21 @@ def check_vendor_specific_dhcp_option(module, ib_spec):
     '''This function will check if the argument dhcp option belongs to vendor-specific and if yes then will remove
      use_options flag which is not supported with vendor-specific dhcp options.
     '''
+    # DHCP option numbers and names that WAPI rejects when use_option is present.
+    # Includes classic vendor-specific options (43, 60, 67, 124, 125) and
+    # structural options that cannot carry a use_option flag (1, 3, 42).
+    # Reference: https://ipam.illinois.edu/wapidoc/additional/structs.html#struct-dhcpoption
+    NO_USE_OPTION_NUMS = frozenset({1, 3, 42, 43, 60, 67, 124, 125})
+    NO_USE_OPTION_NAMES = frozenset({'subnet-mask', 'router', 'ntp-servers'})
     for key, value in ib_spec.items():
         if isinstance(module.params[key], list):
             for temp_dict in module.params[key]:
-                if 'num' in temp_dict:
-                    if temp_dict['num'] in (43, 124, 125, 67, 60):
-                        del temp_dict['use_option']
+                if 'use_option' not in temp_dict:
+                    continue
+                if 'num' in temp_dict and temp_dict['num'] in NO_USE_OPTION_NUMS:
+                    del temp_dict['use_option']
+                elif 'name' in temp_dict and temp_dict['name'] in NO_USE_OPTION_NAMES:
+                    del temp_dict['use_option']
     return ib_spec
 
 

--- a/plugins/modules/nios_range.py
+++ b/plugins/modules/nios_range.py
@@ -316,12 +316,21 @@ def check_vendor_specific_dhcp_option(module, ib_spec):
     '''This function will check if the argument dhcp option belongs to vendor-specific and if yes then will remove
      use_options flag which is not supported with vendor-specific dhcp options.
     '''
+    # DHCP option numbers and names that WAPI rejects when use_option is present.
+    # Includes classic vendor-specific options (43, 60, 67, 124, 125) and
+    # structural options that cannot carry a use_option flag (1, 3, 42).
+    # Reference: https://ipam.illinois.edu/wapidoc/additional/structs.html#struct-dhcpoption
+    NO_USE_OPTION_NUMS = frozenset({1, 3, 42, 43, 60, 67, 124, 125})
+    NO_USE_OPTION_NAMES = frozenset({'subnet-mask', 'router', 'ntp-servers'})
     for key, value in ib_spec.items():
         if isinstance(module.params[key], list):
             for temp_dict in module.params[key]:
-                if 'num' in temp_dict:
-                    if temp_dict['num'] in (43, 124, 125, 67, 60):
-                        del temp_dict['use_option']
+                if 'use_option' not in temp_dict:
+                    continue
+                if 'num' in temp_dict and temp_dict['num'] in NO_USE_OPTION_NUMS:
+                    del temp_dict['use_option']
+                elif 'name' in temp_dict and temp_dict['name'] in NO_USE_OPTION_NAMES:
+                    del temp_dict['use_option']
     return ib_spec
 
 

--- a/plugins/modules/nios_range.py
+++ b/plugins/modules/nios_range.py
@@ -313,8 +313,8 @@ def options(module):
 
 
 def check_vendor_specific_dhcp_option(module, ib_spec):
-    '''This function will check if the argument dhcp option belongs to vendor-specific and if yes then will remove
-     use_options flag which is not supported with vendor-specific dhcp options.
+    '''Remove unsupported `use_option` from DHCP options (vendor-specific and structural).
+     WAPI rejects `use_option` for some option numbers/names.
     '''
     # DHCP option numbers and names that WAPI rejects when use_option is present.
     # Includes classic vendor-specific options (43, 60, 67, 124, 125) and

--- a/tests/unit/plugins/modules/test_nios_network.py
+++ b/tests/unit/plugins/modules/test_nios_network.py
@@ -477,6 +477,13 @@ class TestNiosNetworkModule(TestNiosModule):
         nios_network.check_vendor_specific_dhcp_option(module, ib_spec)
         self.assertNotIn('use_option', module.params['options'][0])
 
+    def test_check_vendor_specific_strips_subnet_mask_by_name(self):
+        # option name='subnet-mask' must have use_option removed
+        opts = [{'name': 'subnet-mask', 'value': '255.255.255.0', 'use_option': True}]
+        module = self._make_module_for_options(opts)
+        ib_spec = {'options': {}}
+        nios_network.check_vendor_specific_dhcp_option(module, ib_spec)
+        self.assertNotIn('use_option', module.params['options'][0])
     def test_check_vendor_specific_preserves_use_option_for_domain_name_servers(self):
         # domain-name-servers (option 6) supports use_option; it must NOT be removed
         opts = [{'name': 'domain-name-servers', 'value': '8.8.8.8', 'use_option': True}]

--- a/tests/unit/plugins/modules/test_nios_network.py
+++ b/tests/unit/plugins/modules/test_nios_network.py
@@ -425,3 +425,74 @@ class TestNiosNetworkModule(TestNiosModule):
                 'vlans': []
             }
         )
+
+    # ------------------------------------------------------------------
+    # Issue #221: structural DHCP options (router/3, ntp-servers/42,
+    # subnet-mask/1) must have use_option stripped before WAPI call.
+    # ------------------------------------------------------------------
+
+    def _make_module_for_options(self, options):
+        """Return a MagicMock module whose params contains the given options list."""
+        m = MagicMock()
+        m.params = {'options': options}
+        return m
+
+    def test_check_vendor_specific_strips_router_by_num(self):
+        # option num=3 (router) must have use_option removed
+        opts = [{'num': 3, 'value': '192.168.10.1', 'use_option': True}]
+        module = self._make_module_for_options(opts)
+        ib_spec = {'options': {}}
+        nios_network.check_vendor_specific_dhcp_option(module, ib_spec)
+        self.assertNotIn('use_option', module.params['options'][0])
+
+    def test_check_vendor_specific_strips_ntp_servers_by_num(self):
+        # option num=42 (ntp-servers) must have use_option removed
+        opts = [{'num': 42, 'value': '10.0.0.1', 'use_option': True}]
+        module = self._make_module_for_options(opts)
+        ib_spec = {'options': {}}
+        nios_network.check_vendor_specific_dhcp_option(module, ib_spec)
+        self.assertNotIn('use_option', module.params['options'][0])
+
+    def test_check_vendor_specific_strips_subnet_mask_by_num(self):
+        # option num=1 (subnet-mask) must have use_option removed
+        opts = [{'num': 1, 'value': '255.255.255.0', 'use_option': True}]
+        module = self._make_module_for_options(opts)
+        ib_spec = {'options': {}}
+        nios_network.check_vendor_specific_dhcp_option(module, ib_spec)
+        self.assertNotIn('use_option', module.params['options'][0])
+
+    def test_check_vendor_specific_strips_router_by_name(self):
+        # option name='router' must have use_option removed (no num supplied)
+        opts = [{'name': 'router', 'value': '192.168.10.1', 'use_option': True}]
+        module = self._make_module_for_options(opts)
+        ib_spec = {'options': {}}
+        nios_network.check_vendor_specific_dhcp_option(module, ib_spec)
+        self.assertNotIn('use_option', module.params['options'][0])
+
+    def test_check_vendor_specific_strips_ntp_servers_by_name(self):
+        # option name='ntp-servers' must have use_option removed
+        opts = [{'name': 'ntp-servers', 'value': '10.0.0.1', 'use_option': True}]
+        module = self._make_module_for_options(opts)
+        ib_spec = {'options': {}}
+        nios_network.check_vendor_specific_dhcp_option(module, ib_spec)
+        self.assertNotIn('use_option', module.params['options'][0])
+
+    def test_check_vendor_specific_preserves_use_option_for_domain_name_servers(self):
+        # domain-name-servers (option 6) supports use_option; it must NOT be removed
+        opts = [{'name': 'domain-name-servers', 'value': '8.8.8.8', 'use_option': True}]
+        module = self._make_module_for_options(opts)
+        ib_spec = {'options': {}}
+        nios_network.check_vendor_specific_dhcp_option(module, ib_spec)
+        self.assertIn('use_option', module.params['options'][0])
+
+    def test_check_vendor_specific_mixed_options(self):
+        # router (stripped) and domain-name-servers (kept) in the same call
+        opts = [
+            {'name': 'router', 'value': '192.168.10.1', 'use_option': True},
+            {'name': 'domain-name-servers', 'value': '8.8.8.8', 'use_option': True},
+        ]
+        module = self._make_module_for_options(opts)
+        ib_spec = {'options': {}}
+        nios_network.check_vendor_specific_dhcp_option(module, ib_spec)
+        self.assertNotIn('use_option', module.params['options'][0])
+        self.assertIn('use_option', module.params['options'][1])

--- a/tests/unit/plugins/modules/test_nios_network.py
+++ b/tests/unit/plugins/modules/test_nios_network.py
@@ -484,6 +484,7 @@ class TestNiosNetworkModule(TestNiosModule):
         ib_spec = {'options': {}}
         nios_network.check_vendor_specific_dhcp_option(module, ib_spec)
         self.assertNotIn('use_option', module.params['options'][0])
+
     def test_check_vendor_specific_preserves_use_option_for_domain_name_servers(self):
         # domain-name-servers (option 6) supports use_option; it must NOT be removed
         opts = [{'name': 'domain-name-servers', 'value': '8.8.8.8', 'use_option': True}]

--- a/tests/unit/plugins/modules/test_nios_range.py
+++ b/tests/unit/plugins/modules/test_nios_range.py
@@ -1,0 +1,78 @@
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from ansible_collections.infoblox.nios_modules.plugins.modules import nios_range
+from ansible_collections.infoblox.nios_modules.tests.unit.compat.mock import MagicMock
+from .test_nios_module import TestNiosModule
+
+
+class TestNiosRangeModule(TestNiosModule):
+
+    module = nios_range
+
+    def _make_module_for_options(self, options):
+        m = MagicMock()
+        m.params = {'options': options}
+        return m
+
+    def test_check_vendor_specific_strips_router_by_num(self):
+        opts = [{'num': 3, 'value': '192.168.10.1', 'use_option': True}]
+        module = self._make_module_for_options(opts)
+        nios_range.check_vendor_specific_dhcp_option(module, {'options': {}})
+        self.assertNotIn('use_option', module.params['options'][0])
+
+    def test_check_vendor_specific_strips_ntp_servers_by_num(self):
+        opts = [{'num': 42, 'value': '10.0.0.1', 'use_option': True}]
+        module = self._make_module_for_options(opts)
+        nios_range.check_vendor_specific_dhcp_option(module, {'options': {}})
+        self.assertNotIn('use_option', module.params['options'][0])
+
+    def test_check_vendor_specific_strips_subnet_mask_by_num(self):
+        opts = [{'num': 1, 'value': '255.255.255.0', 'use_option': True}]
+        module = self._make_module_for_options(opts)
+        nios_range.check_vendor_specific_dhcp_option(module, {'options': {}})
+        self.assertNotIn('use_option', module.params['options'][0])
+
+    def test_check_vendor_specific_strips_router_by_name(self):
+        opts = [{'name': 'router', 'value': '192.168.10.1', 'use_option': True}]
+        module = self._make_module_for_options(opts)
+        nios_range.check_vendor_specific_dhcp_option(module, {'options': {}})
+        self.assertNotIn('use_option', module.params['options'][0])
+
+    def test_check_vendor_specific_strips_ntp_servers_by_name(self):
+        opts = [{'name': 'ntp-servers', 'value': '10.0.0.1', 'use_option': True}]
+        module = self._make_module_for_options(opts)
+        nios_range.check_vendor_specific_dhcp_option(module, {'options': {}})
+        self.assertNotIn('use_option', module.params['options'][0])
+
+    def test_check_vendor_specific_preserves_use_option_for_domain_name_servers(self):
+        opts = [{'name': 'domain-name-servers', 'value': '8.8.8.8', 'use_option': True}]
+        module = self._make_module_for_options(opts)
+        nios_range.check_vendor_specific_dhcp_option(module, {'options': {}})
+        self.assertIn('use_option', module.params['options'][0])
+
+    def test_check_vendor_specific_mixed_options(self):
+        opts = [
+            {'name': 'router', 'value': '192.168.10.1', 'use_option': True},
+            {'name': 'domain-name-servers', 'value': '8.8.8.8', 'use_option': True},
+        ]
+        module = self._make_module_for_options(opts)
+        nios_range.check_vendor_specific_dhcp_option(module, {'options': {}})
+        self.assertNotIn('use_option', module.params['options'][0])
+        self.assertIn('use_option', module.params['options'][1])


### PR DESCRIPTION
…, ntp-servers/42, subnet-mask/1

WAPI rejects any DHCP option object that carries a use_option flag for structural options such as router (3), ntp-servers (42), and subnet-mask (1). The module defaulted use_option=True for every option, so these options always caused:

  'Option router can not have a use_option flag'

The existing check_vendor_specific_dhcp_option() function already stripped use_option for vendor-specific codes (43, 60, 67, 124, 125) but did not include the three structural codes, and did not handle options specified by name instead of number.

Changes:
- Add 1, 3, 42 to the no-use_option set in both nios_network and nios_range
- Also match options passed by name ('router', 'ntp-servers', 'subnet-mask')
- Guard with 'use_option' in temp_dict before deleting to avoid KeyError
- Add 7 unit tests covering by-num, by-name, mixed, and negative cases