### PR TITLE
fix(api): handle None provider when using env vars for NIOS credentials

### DIFF
--- a/plugins/module_utils/api.py
+++ b/plugins/module_utils/api.py
@@ -281,7 +281,7 @@ class WapiBase(object):
     provider_spec = {'provider': dict(type='dict', options=NIOS_PROVIDER_SPEC)}
 
     def __init__(self, provider):
-        self.connector = get_connector(**provider)
+        self.connector = get_connector(**(provider or {}))
 
     def __getattr__(self, name):
         try:


### PR DESCRIPTION
When the 'provider' key is omitted from a task and credentials are supplied via environment variables (INFOBLOX_HOST, INFOBLOX_USERNAME, INFOBLOX_PASSWORD, etc.), module.params['provider'] is None.

Passing None to get_connector(**provider) raises:
  TypeError: argument after ** must be a mapping, not NoneType

Fix: use (provider or {}) so an empty dict is passed instead. get_connector() already handles env var fallback internally, so passing {} correctly triggers env var population.

Fixes #255