### PR TITLE
Add SOURCE_IP_HASH to lb_method choices in nios_dtc_lbdn and nios_dtc…

### DIFF
--- a/plugins/modules/nios_dtc_lbdn.py
+++ b/plugins/modules/nios_dtc_lbdn.py
@@ -288,7 +288,7 @@ def main():
     ib_spec = dict(
         name=dict(required=True, ib_req=True),
         lb_method=dict(required=True, choices=['GLOBAL_AVAILABILITY',
-                                               'RATIO', 'ROUND_ROBIN', 'TOPOLOGY']),
+                                               'RATIO', 'ROUND_ROBIN', 'SOURCE_IP_HASH', 'TOPOLOGY']),
 
         topology=dict(type='str', transform=topology_transform),
         auth_zones=dict(type='list', elements='raw', options=auth_zones_spec,

--- a/plugins/modules/nios_dtc_pool.py
+++ b/plugins/modules/nios_dtc_pool.py
@@ -223,6 +223,7 @@ def main():
                                                          'GLOBAL_AVAILABILITY',
                                                          'RATIO',
                                                          'ROUND_ROBIN',
+                                                         'SOURCE_IP_HASH',
                                                          'TOPOLOGY']),
         lb_preferred_topology=dict(type='str', transform=topology_transform),
 


### PR DESCRIPTION
Adds support for the SOURCE_IP_HASH load balancing method to both the nios_dtc_lbdn and nios_dtc_pool Ansible modules.