### PR TITLE
docs(nios_host_record): document idempotency fixes

### DIFF
--- a/plugins/modules/nios_host_record.py
+++ b/plugins/modules/nios_host_record.py
@@ -22,6 +22,17 @@ requirements:
 extends_documentation_fragment: infoblox.nios_modules.nios
 notes:
     - This module supports C(check_mode).
+    - Re-running a task with the same hostname but a different IP address will
+      not displace or modify existing host records (fixes issue #108).
+    - Alias idempotency - aliases supplied as short (relative) names are
+      automatically expanded to FQDNs before comparison on DNS-enabled host
+      records, preventing false C(changed=True) on re-runs (fixes issue #160).
+    - Host records using C(nios_next_ip) for dynamic IP allocation are
+      idempotent on re-runs; the module detects that the IP has already been
+      allocated and skips the WAPI call (fixes issue #63).
+    - The C(use_for_ea_inheritance) field is stripped from the idempotency
+      comparison to prevent spurious C(changed=True) on every run (fixes
+      issue #108).
 options:
   name:
     description:
@@ -169,6 +180,10 @@ options:
       - Configures an optional list of additional aliases to add to the host
         record. These are equivalent to CNAMEs but held within a host
         record. Must be in list format.
+      - Short (relative) alias names are automatically expanded to FQDNs
+        before the idempotency comparison on DNS-enabled host records, so
+        supplying either the short name or the FQDN produces the same result
+        on re-runs.
     type: list
     elements: str
   ttl:

--- a/plugins/modules/nios_host_record.py
+++ b/plugins/modules/nios_host_record.py
@@ -22,18 +22,22 @@ requirements:
 extends_documentation_fragment: infoblox.nios_modules.nios
 notes:
     - This module supports C(check_mode).
-    - In collection versions that include PR #329 (fixes issue #108), re-running
+    - >
+      In collection versions that include PR #329 (fixes issue #108), re-running
       a task with the same hostname and a different IP updates the matching host
       record without creating, displacing, or modifying unrelated records.
-    - In collection versions that include PR #329 (fixes issue #160), aliases
+    - >
+      In collection versions that include PR #329 (fixes issue #160), aliases
       supplied as short (relative) names are normalized to FQDNs before
       comparison on DNS-enabled hosts, preventing false C(changed=True) on
       re-runs.
-    - In collection versions that include PR #329 (fixes issue #63), host
+    - >
+      In collection versions that include PR #329 (fixes issue #63), host
       records using C(nios_next_ip) for dynamic IP allocation are idempotent on
       re-runs; when the desired IP is already allocated, no additional
       allocation call is made.
-    - In collection versions that include PR #329 (fixes issue #108),
+    - >
+      In collection versions that include PR #329 (fixes issue #108),
       C(use_for_ea_inheritance) defaults are excluded from idempotency
       comparison to prevent spurious C(changed=True) on re-runs.
 options:
@@ -183,10 +187,11 @@ options:
       - Configures an optional list of additional aliases to add to the host
         record. These are equivalent to CNAMEs but held within a host
         record. Must be in list format.
-      - In collection versions that include PR #329 (fixes issue #160), short
+      - >
+        In collection versions that include PR #329 (fixes issue #160), short
         (relative) alias names are normalized to FQDNs on DNS-enabled hosts
-        before idempotency comparison, so short and FQDN forms produce the same
-        result on re-runs.
+        before idempotency comparison, so short and FQDN forms produce the
+        same result on re-runs.
     type: list
     elements: str
   ttl:

--- a/plugins/modules/nios_host_record.py
+++ b/plugins/modules/nios_host_record.py
@@ -22,17 +22,20 @@ requirements:
 extends_documentation_fragment: infoblox.nios_modules.nios
 notes:
     - This module supports C(check_mode).
-    - Re-running a task with the same hostname but a different IP address will
-      not displace or modify existing host records (fixes issue #108).
-    - Alias idempotency - aliases supplied as short (relative) names are
-      automatically expanded to FQDNs before comparison on DNS-enabled host
-      records, preventing false C(changed=True) on re-runs (fixes issue #160).
-    - Host records using C(nios_next_ip) for dynamic IP allocation are
-      idempotent on re-runs; the module detects that the IP has already been
-      allocated and skips the WAPI call (fixes issue #63).
-    - The C(use_for_ea_inheritance) field is stripped from the idempotency
-      comparison to prevent spurious C(changed=True) on every run (fixes
-      issue #108).
+    - In collection versions that include PR #329 (fixes issue #108), re-running
+      a task with the same hostname and a different IP updates the matching host
+      record without creating, displacing, or modifying unrelated records.
+    - In collection versions that include PR #329 (fixes issue #160), aliases
+      supplied as short (relative) names are normalized to FQDNs before
+      comparison on DNS-enabled hosts, preventing false C(changed=True) on
+      re-runs.
+    - In collection versions that include PR #329 (fixes issue #63), host
+      records using C(nios_next_ip) for dynamic IP allocation are idempotent on
+      re-runs; when the desired IP is already allocated, no additional
+      allocation call is made.
+    - In collection versions that include PR #329 (fixes issue #108),
+      C(use_for_ea_inheritance) defaults are excluded from idempotency
+      comparison to prevent spurious C(changed=True) on re-runs.
 options:
   name:
     description:
@@ -180,10 +183,10 @@ options:
       - Configures an optional list of additional aliases to add to the host
         record. These are equivalent to CNAMEs but held within a host
         record. Must be in list format.
-      - Short (relative) alias names are automatically expanded to FQDNs
-        before the idempotency comparison on DNS-enabled host records, so
-        supplying either the short name or the FQDN produces the same result
-        on re-runs.
+      - In collection versions that include PR #329 (fixes issue #160), short
+        (relative) alias names are normalized to FQDNs on DNS-enabled hosts
+        before idempotency comparison, so short and FQDN forms produce the same
+        result on re-runs.
     type: list
     elements: str
   ttl:


### PR DESCRIPTION
## What changed

Updated the `DOCUMENTATION` block in `plugins/modules/nios_host_record.py` to reflect idempotency improvements shipped in #329.

## Related

Companion docs PR for #329 — should be reviewed and merged alongside or after #329.

## Changes

**`notes:` section — 4 new bullets:**
- Host record displacement fix: re-running with the same hostname but a different IP no longer displaces existing records (fixes #108)
- Alias idempotency: short (relative) alias names are automatically expanded to FQDNs before comparison on DNS-enabled hosts, preventing false `changed=True` on re-runs (fixes #160)
- `nios_next_ip` idempotency: module detects the IP has already been allocated on re-runs and skips the WAPI call (fixes #63)
- `use_for_ea_inheritance` stripped from idempotency comparison to prevent spurious `changed=True` on every run (fixes #108)

**`aliases` option description:**
- Added a sentence explaining the short-name → FQDN expansion behaviour for DNS-enabled host records

## No functional changes

This PR is documentation-only. No module logic was modified.