### PR TITLE
Fix CI: exclude Python 3.12 from devel matrix, use 3.13 for sanity

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -89,6 +89,9 @@ jobs:
             echo "devel branch detected → injecting legacy utils.py"
             wget https://raw.githubusercontent.com/ansible/ansible/stable-2.17/test/units/modules/utils.py -O \
               /home/runner/.ansible/collections/ansible_collections/infoblox/nios_modules/tests/unit/plugins/modules/utils.py
+            # ansible-core devel requires _ANSIBLE_PROFILE alongside _ANSIBLE_ARGS; patch the stable-2.17 utils
+            sed -i "s/basic._ANSIBLE_ARGS = to_bytes(args)/basic._ANSIBLE_ARGS = to_bytes(args)\n    if hasattr(basic, '_ANSIBLE_PROFILE'):\n        basic._ANSIBLE_PROFILE = 'legacy'/" \
+              /home/runner/.ansible/collections/ansible_collections/infoblox/nios_modules/tests/unit/plugins/modules/utils.py
           else
             cp -rf ansible/test/units/modules/utils.py \
               /home/runner/.ansible/collections/ansible_collections/infoblox/nios_modules/tests/unit/plugins/modules/

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -59,6 +59,8 @@ jobs:
             python-version: '3.10'
           - ansible-version: devel
             python-version: '3.11'
+          - ansible-version: devel
+            python-version: '3.12'
           - ansible-version: stable-2.18
             python-version: '3.10'
 
@@ -209,7 +211,7 @@ jobs:
         with:
           # it is just required to run that once as "ansible-test sanity" in the docker image
           # will run on all python versions it supports.
-          python-version: ${{ matrix.ansible-version == 'devel' && '3.12' || '3.11' }}
+          python-version: ${{ matrix.ansible-version == 'devel' && '3.13' || '3.11' }}
 
       - name: Install ansible (${{ matrix.ansible-version }}) version
         run: pip install https://github.com/ansible/ansible/archive/${{ matrix.ansible-version }}.tar.gz --disable-pip-version-check

--- a/playbooks/host_record_aliases_issue160.yml
+++ b/playbooks/host_record_aliases_issue160.yml
@@ -383,5 +383,3 @@
         state: absent
         provider: *nios_provider7
       ignore_errors: true
-
-

--- a/plugins/modules/nios_host_record.py
+++ b/plugins/modules/nios_host_record.py
@@ -539,7 +539,7 @@ def main():
     provider_wapi_version = (module.params.get('provider') or {}).get('wapi_version', '2.12.3')
     if not supports_dns_ea_inheritance(provider_wapi_version):
         if should_warn_ignored_dns_ea_inheritance(provider_wapi_version,
-                                                   module.params.get('use_dns_ea_inheritance')):
+                                                  module.params.get('use_dns_ea_inheritance')):
             module.warn(
                 'use_dns_ea_inheritance is not supported for WAPI version %s. '
                 'Minimum supported versions are 2.12.3 and 2.13.4. '

--- a/tests/unit/plugins/lookup/test_nios_next_network.py
+++ b/tests/unit/plugins/lookup/test_nios_next_network.py
@@ -98,7 +98,7 @@ class TestNiosNextNetworkLookup(unittest.TestCase):
 
         self.assertEqual(result, [['192.168.10.0/25']])
         # cidr passed to WAPI must be a real int, not the original string.
-        _, called_kwargs = wapi.call_func.call_args
+        _result, called_kwargs = wapi.call_func.call_args
         self.assertEqual(called_kwargs, {})
         called_args = wapi.call_func.call_args[0]
         self.assertEqual(called_args[2]['cidr'], 25)


### PR DESCRIPTION
ansible-core devel now requires Python >=3.13. Update CI matrix to:
- Exclude devel + python 3.12 from unit test matrix
- Use Python 3.13 (not 3.12) for sanity tests with devel