### PR TITLE
Fix #115: Improve exclude handling for nios_next_ip allocation

### DIFF
--- a/changelogs/fragments/115-nios_next_ip-exclude-unsupported.yml
+++ b/changelogs/fragments/115-nios_next_ip-exclude-unsupported.yml
@@ -1,0 +1,10 @@
+---
+bugfixes:
+  - |
+    nios_host_record - fail with an actionable error when ``exclude`` is supplied
+    inside the inline ``nios_next_ip`` dictionary. That syntax maps to the WAPI
+    ``func:nextavailableip`` call, which does not accept an ``exclude`` argument,
+    so the option was previously ignored and an excluded address could still be
+    allocated. The module now points users to the ``nios_next_ip`` lookup plugin,
+    which supports ``exclude``
+    (https://github.com/infobloxopen/infoblox-ansible/issues/115).

--- a/plugins/module_utils/api.py
+++ b/plugins/module_utils/api.py
@@ -760,19 +760,19 @@ class WapiModule(WapiBase):
         ''' Check if nios_next_ip argument is passed in ipaddr while creating
             host record, if yes then format proposed object ipv4addrs and pass
             func:nextavailableip and ipaddr range to create hostrecord with next
-             available ip in one call to avoid any race condition.
-            
-            If 'exclude' parameter is also present in the dict, pre-call
-            next_available_ip separately (since func:nextavailableip string
-            format does not support exclude) and replace with the allocated IP.
-        '''
+            available ip.
 
+            When 'exclude' is also present in the dict, a WAPI race condition
+            cannot be avoided because func:nextavailableip does not accept an
+            exclude parameter. In that case, next_available_ip is called first
+            to obtain a concrete IP, then that IP is used in the create call.
+            If 'exclude' is absent the original single-call path is used.
+        '''
         if 'ipv4addrs' in proposed_object:
             if 'nios_next_ip' in proposed_object['ipv4addrs'][0]['ipv4addr']:
                 ipv4addr_dict = check_type_dict(proposed_object['ipv4addrs'][0]['ipv4addr'])
                 ip_range = ipv4addr_dict['nios_next_ip']
                 exclude_ips = ipv4addr_dict.get('exclude', [])
-                
                 if exclude_ips:
                     # exclude parameter present - must pre-call next_available_ip
                     # since func:nextavailableip string format doesn't support exclude
@@ -783,14 +783,12 @@ class WapiModule(WapiBase):
                 else:
                     # no exclude - use standard func:nextavailableip string (current behavior)
                     proposed_object['ipv4addrs'][0]['ipv4addr'] = NIOS_NEXT_AVAILABLE_IP + ':' + ip_range
-                    
         elif 'ipv4addr' in proposed_object:
             if 'nios_next_ip' in proposed_object['ipv4addr']:
                 ipv4addr_dict = check_type_dict(proposed_object['ipv4addr'])
                 ip_range = ipv4addr_dict['nios_next_ip']
                 exclude_ips = ipv4addr_dict.get('exclude', [])
                 net_view = self.get_network_view(proposed_object)
-                
                 if exclude_ips:
                     # exclude parameter present - must pre-call next_available_ip
                     allocated_ip = self._allocate_next_ip_with_exclude(
@@ -799,43 +797,47 @@ class WapiModule(WapiBase):
                 else:
                     # no exclude - use standard func:nextavailableip string (current behavior)
                     proposed_object['ipv4addr'] = NIOS_NEXT_AVAILABLE_IP + ':' + ip_range + ',' + net_view
-
         return proposed_object
 
     def _allocate_next_ip_with_exclude(self, cidr, network_view, exclude_list, ip_type):
         ''' Allocate next available IP with exclusion list by pre-calling
             next_available_ip WAPI function.
-            
+
             :param cidr: Network CIDR (e.g., '192.168.1.0/24')
             :param network_view: Network view name
-            :param exclude_list: List of IPs to exclude
+            :param exclude_list: List of IPs to exclude (a string is treated as
+                a single-element list; any other non-list type raises an error)
             :param ip_type: 'ipv4' or 'ipv6'
             :returns: Allocated IP address string
         '''
-        # Determine object type based on IP version
-        if ip_type == 'ipv6':
-            obj_type = 'ipv6network'
+        # Normalise exclude_list so WAPI always receives a proper list
+        if exclude_list is None:
+            exclude_list = []
+        elif isinstance(exclude_list, (str, bytes)):
+            exclude_list = [exclude_list]
+        elif not isinstance(exclude_list, (list, tuple)):
+            self.module.fail_json(
+                msg="'exclude' must be a list of IP addresses, got %s" % type(exclude_list).__name__
+            )
         else:
-            obj_type = 'network'
-        
+            exclude_list = list(exclude_list)
+        # Determine object type based on IP version
+        obj_type = 'ipv6network' if ip_type == 'ipv6' else 'network'
         # Get network object reference
         try:
             network_obj = self.connector.get_object(
-                obj_type, 
+                obj_type,
                 {'network': cidr, 'network_view': network_view}
             )
         except Exception as exc:
             self.module.fail_json(
                 msg='Failed to find network %s in view %s: %s' % (cidr, network_view, str(exc))
             )
-        
         if not network_obj:
             self.module.fail_json(
                 msg='Network %s not found in network view %s' % (cidr, network_view)
             )
-        
         network_ref = network_obj[0]['_ref']
-        
         # Call next_available_ip with exclude list
         try:
             result = self.connector.call_func(
@@ -845,15 +847,13 @@ class WapiModule(WapiBase):
             )
         except Exception as exc:
             self.module.fail_json(
-                msg='Failed to allocate next available IP from %s (excluding %s): %s' % 
-                (cidr, exclude_list, str(exc))
+                msg='Failed to allocate next available IP from %s (excluding %s): %s' % (
+                    cidr, exclude_list, str(exc))
             )
-        
         if 'ips' not in result or len(result['ips']) == 0:
             self.module.fail_json(
                 msg='No available IPs in network %s after excluding %s' % (cidr, exclude_list)
             )
-        
         return result['ips'][0]
 
     def check_for_new_ipv4addr(self, proposed_object):

--- a/plugins/module_utils/api.py
+++ b/plugins/module_utils/api.py
@@ -760,19 +760,101 @@ class WapiModule(WapiBase):
         ''' Check if nios_next_ip argument is passed in ipaddr while creating
             host record, if yes then format proposed object ipv4addrs and pass
             func:nextavailableip and ipaddr range to create hostrecord with next
-             available ip in one call to avoid any race condition '''
+             available ip in one call to avoid any race condition.
+            
+            If 'exclude' parameter is also present in the dict, pre-call
+            next_available_ip separately (since func:nextavailableip string
+            format does not support exclude) and replace with the allocated IP.
+        '''
 
         if 'ipv4addrs' in proposed_object:
             if 'nios_next_ip' in proposed_object['ipv4addrs'][0]['ipv4addr']:
-                ip_range = check_type_dict(proposed_object['ipv4addrs'][0]['ipv4addr'])['nios_next_ip']
-                proposed_object['ipv4addrs'][0]['ipv4addr'] = NIOS_NEXT_AVAILABLE_IP + ':' + ip_range
+                ipv4addr_dict = check_type_dict(proposed_object['ipv4addrs'][0]['ipv4addr'])
+                ip_range = ipv4addr_dict['nios_next_ip']
+                exclude_ips = ipv4addr_dict.get('exclude', [])
+                
+                if exclude_ips:
+                    # exclude parameter present - must pre-call next_available_ip
+                    # since func:nextavailableip string format doesn't support exclude
+                    net_view = self.get_network_view(proposed_object)
+                    allocated_ip = self._allocate_next_ip_with_exclude(
+                        ip_range, net_view, exclude_ips, 'ipv4')
+                    proposed_object['ipv4addrs'][0]['ipv4addr'] = allocated_ip
+                else:
+                    # no exclude - use standard func:nextavailableip string (current behavior)
+                    proposed_object['ipv4addrs'][0]['ipv4addr'] = NIOS_NEXT_AVAILABLE_IP + ':' + ip_range
+                    
         elif 'ipv4addr' in proposed_object:
             if 'nios_next_ip' in proposed_object['ipv4addr']:
-                ip_range = check_type_dict(proposed_object['ipv4addr'])['nios_next_ip']
+                ipv4addr_dict = check_type_dict(proposed_object['ipv4addr'])
+                ip_range = ipv4addr_dict['nios_next_ip']
+                exclude_ips = ipv4addr_dict.get('exclude', [])
                 net_view = self.get_network_view(proposed_object)
-                proposed_object['ipv4addr'] = NIOS_NEXT_AVAILABLE_IP + ':' + ip_range + ',' + net_view
+                
+                if exclude_ips:
+                    # exclude parameter present - must pre-call next_available_ip
+                    allocated_ip = self._allocate_next_ip_with_exclude(
+                        ip_range, net_view, exclude_ips, 'ipv4')
+                    proposed_object['ipv4addr'] = allocated_ip
+                else:
+                    # no exclude - use standard func:nextavailableip string (current behavior)
+                    proposed_object['ipv4addr'] = NIOS_NEXT_AVAILABLE_IP + ':' + ip_range + ',' + net_view
 
         return proposed_object
+
+    def _allocate_next_ip_with_exclude(self, cidr, network_view, exclude_list, ip_type):
+        ''' Allocate next available IP with exclusion list by pre-calling
+            next_available_ip WAPI function.
+            
+            :param cidr: Network CIDR (e.g., '192.168.1.0/24')
+            :param network_view: Network view name
+            :param exclude_list: List of IPs to exclude
+            :param ip_type: 'ipv4' or 'ipv6'
+            :returns: Allocated IP address string
+        '''
+        # Determine object type based on IP version
+        if ip_type == 'ipv6':
+            obj_type = 'ipv6network'
+        else:
+            obj_type = 'network'
+        
+        # Get network object reference
+        try:
+            network_obj = self.connector.get_object(
+                obj_type, 
+                {'network': cidr, 'network_view': network_view}
+            )
+        except Exception as exc:
+            self.module.fail_json(
+                msg='Failed to find network %s in view %s: %s' % (cidr, network_view, str(exc))
+            )
+        
+        if not network_obj:
+            self.module.fail_json(
+                msg='Network %s not found in network view %s' % (cidr, network_view)
+            )
+        
+        network_ref = network_obj[0]['_ref']
+        
+        # Call next_available_ip with exclude list
+        try:
+            result = self.connector.call_func(
+                'next_available_ip',
+                network_ref,
+                {'num': 1, 'exclude': exclude_list}
+            )
+        except Exception as exc:
+            self.module.fail_json(
+                msg='Failed to allocate next available IP from %s (excluding %s): %s' % 
+                (cidr, exclude_list, str(exc))
+            )
+        
+        if 'ips' not in result or len(result['ips']) == 0:
+            self.module.fail_json(
+                msg='No available IPs in network %s after excluding %s' % (cidr, exclude_list)
+            )
+        
+        return result['ips'][0]
 
     def check_for_new_ipv4addr(self, proposed_object):
         ''' Checks if new_ipv4addr parameter is passed in the argument

--- a/plugins/module_utils/api.py
+++ b/plugins/module_utils/api.py
@@ -760,101 +760,41 @@ class WapiModule(WapiBase):
         ''' Check if nios_next_ip argument is passed in ipaddr while creating
             host record, if yes then format proposed object ipv4addrs and pass
             func:nextavailableip and ipaddr range to create hostrecord with next
-            available ip.
+             available ip in one call to avoid any race condition '''
 
-            When 'exclude' is also present in the dict, a WAPI race condition
-            cannot be avoided because func:nextavailableip does not accept an
-            exclude parameter. In that case, next_available_ip is called first
-            to obtain a concrete IP, then that IP is used in the create call.
-            If 'exclude' is absent the original single-call path is used.
-        '''
         if 'ipv4addrs' in proposed_object:
             if 'nios_next_ip' in proposed_object['ipv4addrs'][0]['ipv4addr']:
                 ipv4addr_dict = check_type_dict(proposed_object['ipv4addrs'][0]['ipv4addr'])
+                self._reject_unsupported_next_ip_exclude(ipv4addr_dict)
                 ip_range = ipv4addr_dict['nios_next_ip']
-                exclude_ips = ipv4addr_dict.get('exclude', [])
-                if exclude_ips:
-                    # exclude parameter present - must pre-call next_available_ip
-                    # since func:nextavailableip string format doesn't support exclude
-                    net_view = self.get_network_view(proposed_object)
-                    allocated_ip = self._allocate_next_ip_with_exclude(
-                        ip_range, net_view, exclude_ips, 'ipv4')
-                    proposed_object['ipv4addrs'][0]['ipv4addr'] = allocated_ip
-                else:
-                    # no exclude - use standard func:nextavailableip string (current behavior)
-                    proposed_object['ipv4addrs'][0]['ipv4addr'] = NIOS_NEXT_AVAILABLE_IP + ':' + ip_range
+                proposed_object['ipv4addrs'][0]['ipv4addr'] = NIOS_NEXT_AVAILABLE_IP + ':' + ip_range
         elif 'ipv4addr' in proposed_object:
             if 'nios_next_ip' in proposed_object['ipv4addr']:
                 ipv4addr_dict = check_type_dict(proposed_object['ipv4addr'])
+                self._reject_unsupported_next_ip_exclude(ipv4addr_dict)
                 ip_range = ipv4addr_dict['nios_next_ip']
-                exclude_ips = ipv4addr_dict.get('exclude', [])
                 net_view = self.get_network_view(proposed_object)
-                if exclude_ips:
-                    # exclude parameter present - must pre-call next_available_ip
-                    allocated_ip = self._allocate_next_ip_with_exclude(
-                        ip_range, net_view, exclude_ips, 'ipv4')
-                    proposed_object['ipv4addr'] = allocated_ip
-                else:
-                    # no exclude - use standard func:nextavailableip string (current behavior)
-                    proposed_object['ipv4addr'] = NIOS_NEXT_AVAILABLE_IP + ':' + ip_range + ',' + net_view
+                proposed_object['ipv4addr'] = NIOS_NEXT_AVAILABLE_IP + ':' + ip_range + ',' + net_view
+
         return proposed_object
 
-    def _allocate_next_ip_with_exclude(self, cidr, network_view, exclude_list, ip_type):
-        ''' Allocate next available IP with exclusion list by pre-calling
-            next_available_ip WAPI function.
-
-            :param cidr: Network CIDR (e.g., '192.168.1.0/24')
-            :param network_view: Network view name
-            :param exclude_list: List of IPs to exclude (a string is treated as
-                a single-element list; any other non-list type raises an error)
-            :param ip_type: 'ipv4' or 'ipv6'
-            :returns: Allocated IP address string
-        '''
-        # Normalise exclude_list so WAPI always receives a proper list
-        if exclude_list is None:
-            exclude_list = []
-        elif isinstance(exclude_list, (str, bytes)):
-            exclude_list = [exclude_list]
-        elif not isinstance(exclude_list, (list, tuple)):
+    def _reject_unsupported_next_ip_exclude(self, ipv4addr_dict):
+        ''' The inline ``nios_next_ip`` syntax maps to the WAPI
+            ``func:nextavailableip`` call, which allocates an address
+            atomically on the server but does not accept an ``exclude``
+            argument. Rather than silently ignoring ``exclude`` (and handing
+            back an address the user asked to avoid), fail with an actionable
+            message pointing to the ``nios_next_ip`` lookup plugin, which does
+            support ``exclude``. '''
+        if ipv4addr_dict.get('exclude'):
             self.module.fail_json(
-                msg="'exclude' must be a list of IP addresses, got %s" % type(exclude_list).__name__
+                msg="The 'exclude' option is not supported with the inline "
+                    "'nios_next_ip' syntax because it maps to the WAPI "
+                    "func:nextavailableip call. Use the 'nios_next_ip' lookup "
+                    "plugin (infoblox.nios_modules.nios_next_ip), which supports "
+                    "'exclude', to allocate an address and pass the result to "
+                    "this module."
             )
-        else:
-            exclude_list = list(exclude_list)
-        # Determine object type based on IP version
-        obj_type = 'ipv6network' if ip_type == 'ipv6' else 'network'
-        # Get network object reference
-        try:
-            network_obj = self.connector.get_object(
-                obj_type,
-                {'network': cidr, 'network_view': network_view}
-            )
-        except Exception as exc:
-            self.module.fail_json(
-                msg='Failed to find network %s in view %s: %s' % (cidr, network_view, str(exc))
-            )
-        if not network_obj:
-            self.module.fail_json(
-                msg='Network %s not found in network view %s' % (cidr, network_view)
-            )
-        network_ref = network_obj[0]['_ref']
-        # Call next_available_ip with exclude list
-        try:
-            result = self.connector.call_func(
-                'next_available_ip',
-                network_ref,
-                {'num': 1, 'exclude': exclude_list}
-            )
-        except Exception as exc:
-            self.module.fail_json(
-                msg='Failed to allocate next available IP from %s (excluding %s): %s' % (
-                    cidr, exclude_list, str(exc))
-            )
-        if 'ips' not in result or len(result['ips']) == 0:
-            self.module.fail_json(
-                msg='No available IPs in network %s after excluding %s' % (cidr, exclude_list)
-            )
-        return result['ips'][0]
 
     def check_for_new_ipv4addr(self, proposed_object):
         ''' Checks if new_ipv4addr parameter is passed in the argument

--- a/plugins/modules/nios_host_record.py
+++ b/plugins/modules/nios_host_record.py
@@ -362,13 +362,20 @@ EXAMPLES = '''
       password: admin
   connection: local
 
+# The inline 'nios_next_ip' syntax maps to the WAPI func:nextavailableip call,
+# which allocates an address atomically but does not support excluding IPs.
+# To allocate the next available IP while excluding specific addresses, use the
+# 'nios_next_ip' lookup plugin (which supports 'exclude') and pass the result to
+# this module.
 - name: Dynamically add host record to next available ip excluding specific IPs
   infoblox.nios_modules.nios_host_record:
     name: host.ansible.com
     ipv4:
-      - address:
-          nios_next_ip: 192.168.10.0/24
-          exclude: ['192.168.10.1', '192.168.10.2', '192.168.10.3', '192.168.10.4', '192.168.10.5']
+      - address: "{{ lookup('infoblox.nios_modules.nios_next_ip',
+                     '192.168.10.0/24',
+                     exclude=['192.168.10.1', '192.168.10.2', '192.168.10.3',
+                              '192.168.10.4', '192.168.10.5'],
+                     provider=provider) }}"
     comment: Skip first 5 IPs (typically reserved for gateway, DNS, etc.)
     state: present
     provider:

--- a/plugins/modules/nios_host_record.py
+++ b/plugins/modules/nios_host_record.py
@@ -362,6 +362,21 @@ EXAMPLES = '''
       password: admin
   connection: local
 
+- name: Dynamically add host record to next available ip excluding specific IPs
+  infoblox.nios_modules.nios_host_record:
+    name: host.ansible.com
+    ipv4:
+      - address:
+          nios_next_ip: 192.168.10.0/24
+          exclude: ['192.168.10.1', '192.168.10.2', '192.168.10.3', '192.168.10.4', '192.168.10.5']
+    comment: Skip first 5 IPs (typically reserved for gateway, DNS, etc.)
+    state: present
+    provider:
+      host: "{{ inventory_hostname_short }}"
+      username: admin
+      password: admin
+  connection: local
+
 - name: Add ip to host record
   infoblox.nios_modules.nios_host_record:
     name: host.ansible.com

--- a/tests/unit/plugins/modules/test_nios_host_record.py
+++ b/tests/unit/plugins/modules/test_nios_host_record.py
@@ -213,3 +213,125 @@ class TestNiosHostRecordModule(TestNiosModule):
         self.assertTrue(nios_host_record.should_warn_ignored_dns_ea_inheritance('2.12', True))
         self.assertFalse(nios_host_record.should_warn_ignored_dns_ea_inheritance('2.12', False))
         self.assertFalse(nios_host_record.should_warn_ignored_dns_ea_inheritance('2.12.3', True))
+
+    # ------------------------------------------------------------------
+    # Tests for issue #115: exclude parameter in inline nios_next_ip
+    # ------------------------------------------------------------------
+
+    def _get_wapi_with_connector(self):
+        wapi = api.WapiModule(self.module)
+        wapi.get_object = Mock(name='get_object', return_value=None)
+        wapi.create_object = Mock(name='create_object')
+        wapi.update_object = Mock(name='update_object')
+        wapi.delete_object = Mock(name='delete_object')
+        wapi.connector = MagicMock()
+        # Make fail_json raise so execution stops after the first error, matching
+        # real Ansible module behaviour.
+        self.module.fail_json.side_effect = SystemExit(1)
+        return wapi
+
+    def test_allocate_next_ip_with_exclude_list(self):
+        """_allocate_next_ip_with_exclude returns first IP from WAPI result."""
+        network_ref = 'network/ZG5z:192.168.1.0/24/default'
+        wapi = self._get_wapi_with_connector()
+        wapi.connector.get_object.return_value = [{'_ref': network_ref}]
+        wapi.connector.call_func.return_value = {'ips': ['192.168.1.5']}
+
+        result = wapi._allocate_next_ip_with_exclude(
+            '192.168.1.0/24', 'default', ['192.168.1.1', '192.168.1.2'], 'ipv4'
+        )
+
+        self.assertEqual(result, '192.168.1.5')
+        wapi.connector.call_func.assert_called_once_with(
+            'next_available_ip',
+            network_ref,
+            {'num': 1, 'exclude': ['192.168.1.1', '192.168.1.2']}
+        )
+
+    def test_allocate_next_ip_with_exclude_string_normalised_to_list(self):
+        """A single IP string passed as exclude is normalised to a list."""
+        network_ref = 'network/ZG5z:192.168.1.0/24/default'
+        wapi = self._get_wapi_with_connector()
+        wapi.connector.get_object.return_value = [{'_ref': network_ref}]
+        wapi.connector.call_func.return_value = {'ips': ['192.168.1.2']}
+
+        result = wapi._allocate_next_ip_with_exclude(
+            '192.168.1.0/24', 'default', '192.168.1.1', 'ipv4'
+        )
+
+        self.assertEqual(result, '192.168.1.2')
+        wapi.connector.call_func.assert_called_once_with(
+            'next_available_ip',
+            network_ref,
+            {'num': 1, 'exclude': ['192.168.1.1']}
+        )
+
+    def test_allocate_next_ip_with_exclude_invalid_type_fails(self):
+        """A non-string, non-list exclude value causes fail_json."""
+        wapi = self._get_wapi_with_connector()
+
+        with self.assertRaises(SystemExit):
+            wapi._allocate_next_ip_with_exclude(
+                '192.168.1.0/24', 'default', 12345, 'ipv4'
+            )
+
+        self.assertTrue(self.module.fail_json.called)
+        self.assertIn('exclude', self.module.fail_json.call_args[1]['msg'])
+
+    def test_allocate_next_ip_network_not_found_fails(self):
+        """fail_json is called when the network does not exist."""
+        wapi = self._get_wapi_with_connector()
+        wapi.connector.get_object.return_value = None
+
+        with self.assertRaises(SystemExit):
+            wapi._allocate_next_ip_with_exclude(
+                '10.0.0.0/24', 'default', ['10.0.0.1'], 'ipv4'
+            )
+
+        self.assertTrue(self.module.fail_json.called)
+        self.assertIn('not found', self.module.fail_json.call_args[1]['msg'])
+
+    def test_check_if_nios_next_ip_exists_with_exclude_replaces_addr(self):
+        """check_if_nios_next_ip_exists replaces nios_next_ip dict with concrete IP
+        when exclude is present."""
+        network_ref = 'network/ZG5z:192.168.10.0/24/default'
+        wapi = self._get_wapi_with_connector()
+        wapi.connector.get_object.return_value = [{'_ref': network_ref}]
+        wapi.connector.call_func.return_value = {'ips': ['192.168.10.6']}
+
+        proposed = {
+            'ipv4addrs': [{
+                'ipv4addr': "{'nios_next_ip': '192.168.10.0/24', 'exclude': ['192.168.10.1']}",
+                'configure_for_dhcp': False,
+            }],
+            'view': 'default',
+        }
+
+        from ansible.module_utils.common.validation import check_type_dict as real_ctd
+        self.mock_check_type_dict_obj.side_effect = real_ctd
+
+        result = wapi.check_if_nios_next_ip_exists(proposed)
+
+        self.assertEqual(result['ipv4addrs'][0]['ipv4addr'], '192.168.10.6')
+
+    def test_check_if_nios_next_ip_exists_without_exclude_uses_func_string(self):
+        """check_if_nios_next_ip_exists keeps func:nextavailableip string path
+        when no exclude is given (backward compatibility)."""
+        wapi = self._get_wapi_with_connector()
+
+        proposed = {
+            'ipv4addrs': [{
+                'ipv4addr': "{'nios_next_ip': '192.168.10.0/24'}",
+                'configure_for_dhcp': False,
+            }],
+            'view': 'default',
+        }
+
+        from ansible.module_utils.common.validation import check_type_dict as real_ctd
+        self.mock_check_type_dict_obj.side_effect = real_ctd
+
+        result = wapi.check_if_nios_next_ip_exists(proposed)
+
+        addr = result['ipv4addrs'][0]['ipv4addr']
+        self.assertTrue(addr.startswith('func:nextavailableip:'),
+                        msg='Expected func:nextavailableip prefix, got: %s' % addr)

--- a/tests/unit/plugins/modules/test_nios_host_record.py
+++ b/tests/unit/plugins/modules/test_nios_host_record.py
@@ -215,7 +215,9 @@ class TestNiosHostRecordModule(TestNiosModule):
         self.assertFalse(nios_host_record.should_warn_ignored_dns_ea_inheritance('2.12.3', True))
 
     # ------------------------------------------------------------------
-    # Tests for issue #115: exclude parameter in inline nios_next_ip
+    # Tests for issue #115: exclude is not supported with the inline
+    # nios_next_ip syntax (it maps to func:nextavailableip). The module must
+    # fail with an actionable message instead of silently ignoring exclude.
     # ------------------------------------------------------------------
 
     def _get_wapi_with_connector(self):
@@ -230,74 +232,10 @@ class TestNiosHostRecordModule(TestNiosModule):
         self.module.fail_json.side_effect = SystemExit(1)
         return wapi
 
-    def test_allocate_next_ip_with_exclude_list(self):
-        """_allocate_next_ip_with_exclude returns first IP from WAPI result."""
-        network_ref = 'network/ZG5z:192.168.1.0/24/default'
+    def test_check_if_nios_next_ip_exists_with_exclude_host_fails(self):
+        """An inline nios_next_ip dict with exclude (host ipv4addrs) must fail
+        with a message pointing to the nios_next_ip lookup plugin."""
         wapi = self._get_wapi_with_connector()
-        wapi.connector.get_object.return_value = [{'_ref': network_ref}]
-        wapi.connector.call_func.return_value = {'ips': ['192.168.1.5']}
-
-        result = wapi._allocate_next_ip_with_exclude(
-            '192.168.1.0/24', 'default', ['192.168.1.1', '192.168.1.2'], 'ipv4'
-        )
-
-        self.assertEqual(result, '192.168.1.5')
-        wapi.connector.call_func.assert_called_once_with(
-            'next_available_ip',
-            network_ref,
-            {'num': 1, 'exclude': ['192.168.1.1', '192.168.1.2']}
-        )
-
-    def test_allocate_next_ip_with_exclude_string_normalised_to_list(self):
-        """A single IP string passed as exclude is normalised to a list."""
-        network_ref = 'network/ZG5z:192.168.1.0/24/default'
-        wapi = self._get_wapi_with_connector()
-        wapi.connector.get_object.return_value = [{'_ref': network_ref}]
-        wapi.connector.call_func.return_value = {'ips': ['192.168.1.2']}
-
-        result = wapi._allocate_next_ip_with_exclude(
-            '192.168.1.0/24', 'default', '192.168.1.1', 'ipv4'
-        )
-
-        self.assertEqual(result, '192.168.1.2')
-        wapi.connector.call_func.assert_called_once_with(
-            'next_available_ip',
-            network_ref,
-            {'num': 1, 'exclude': ['192.168.1.1']}
-        )
-
-    def test_allocate_next_ip_with_exclude_invalid_type_fails(self):
-        """A non-string, non-list exclude value causes fail_json."""
-        wapi = self._get_wapi_with_connector()
-
-        with self.assertRaises(SystemExit):
-            wapi._allocate_next_ip_with_exclude(
-                '192.168.1.0/24', 'default', 12345, 'ipv4'
-            )
-
-        self.assertTrue(self.module.fail_json.called)
-        self.assertIn('exclude', self.module.fail_json.call_args[1]['msg'])
-
-    def test_allocate_next_ip_network_not_found_fails(self):
-        """fail_json is called when the network does not exist."""
-        wapi = self._get_wapi_with_connector()
-        wapi.connector.get_object.return_value = None
-
-        with self.assertRaises(SystemExit):
-            wapi._allocate_next_ip_with_exclude(
-                '10.0.0.0/24', 'default', ['10.0.0.1'], 'ipv4'
-            )
-
-        self.assertTrue(self.module.fail_json.called)
-        self.assertIn('not found', self.module.fail_json.call_args[1]['msg'])
-
-    def test_check_if_nios_next_ip_exists_with_exclude_replaces_addr(self):
-        """check_if_nios_next_ip_exists replaces nios_next_ip dict with concrete IP
-        when exclude is present."""
-        network_ref = 'network/ZG5z:192.168.10.0/24/default'
-        wapi = self._get_wapi_with_connector()
-        wapi.connector.get_object.return_value = [{'_ref': network_ref}]
-        wapi.connector.call_func.return_value = {'ips': ['192.168.10.6']}
 
         proposed = {
             'ipv4addrs': [{
@@ -309,14 +247,39 @@ class TestNiosHostRecordModule(TestNiosModule):
 
         from ansible.module_utils.common.validation import check_type_dict as real_ctd
         self.mock_check_type_dict_obj.side_effect = real_ctd
+        self.module.fail_json.reset_mock()
 
-        result = wapi.check_if_nios_next_ip_exists(proposed)
+        with self.assertRaises(SystemExit):
+            wapi.check_if_nios_next_ip_exists(proposed)
 
-        self.assertEqual(result['ipv4addrs'][0]['ipv4addr'], '192.168.10.6')
+        self.assertTrue(self.module.fail_json.called)
+        msg = self.module.fail_json.call_args[1]['msg']
+        self.assertIn('exclude', msg)
+        self.assertIn('nios_next_ip', msg)
+
+    def test_check_if_nios_next_ip_exists_with_exclude_ipv4addr_fails(self):
+        """An inline nios_next_ip dict with exclude (plain ipv4addr) must also
+        fail with the same actionable message."""
+        wapi = self._get_wapi_with_connector()
+
+        proposed = {
+            'ipv4addr': "{'nios_next_ip': '192.168.10.0/24', 'exclude': ['192.168.10.1']}",
+            'view': 'default',
+        }
+
+        from ansible.module_utils.common.validation import check_type_dict as real_ctd
+        self.mock_check_type_dict_obj.side_effect = real_ctd
+        self.module.fail_json.reset_mock()
+
+        with self.assertRaises(SystemExit):
+            wapi.check_if_nios_next_ip_exists(proposed)
+
+        self.assertTrue(self.module.fail_json.called)
+        self.assertIn('exclude', self.module.fail_json.call_args[1]['msg'])
 
     def test_check_if_nios_next_ip_exists_without_exclude_uses_func_string(self):
         """check_if_nios_next_ip_exists keeps func:nextavailableip string path
-        when no exclude is given (backward compatibility)."""
+        when no exclude is given (existing behaviour is preserved)."""
         wapi = self._get_wapi_with_connector()
 
         proposed = {
@@ -330,8 +293,13 @@ class TestNiosHostRecordModule(TestNiosModule):
         from ansible.module_utils.common.validation import check_type_dict as real_ctd
         self.mock_check_type_dict_obj.side_effect = real_ctd
 
+        # Ignore any fail_json calls made while constructing the connector;
+        # we only care whether the function under test triggers one.
+        self.module.fail_json.reset_mock()
+
         result = wapi.check_if_nios_next_ip_exists(proposed)
 
         addr = result['ipv4addrs'][0]['ipv4addr']
         self.assertTrue(addr.startswith('func:nextavailableip:'),
                         msg='Expected func:nextavailableip prefix, got: %s' % addr)
+        self.assertFalse(self.module.fail_json.called)


### PR DESCRIPTION
Fix #115 by preserving the existing atomic `nios_next_ip` workflow and
documenting the supported way to allocate an address while excluding specific IPs.

### 
- Keep inline `nios_next_ip` mapped to WAPI `func:nextavailableip`
- Guide exclusion-based allocation to the `infoblox.nios_modules.nios_next_ip` lookup plugin
- Add tests and documentation for the supported flow