### PR TITLE
Fix #114: nios_fixed_address state=absent silently ignores deletion

### DIFF
--- a/plugins/module_utils/api.py
+++ b/plugins/module_utils/api.py
@@ -1084,10 +1084,19 @@ class WapiModule(WapiBase):
                 # Searching by mac alone returns all fixed addresses with that mac across
                 # all networks, which can cause the wrong record to be deleted or no match
                 # to be found (silent no-op on state=absent).
-                test_obj_filter = dict([['mac', obj_filter['mac']], ['ipv4addr', obj_filter['ipv4addr']]])
+                # Guard against ipv4addr being absent so callers that only supply mac
+                # fall back to the mac-only filter rather than raising KeyError.
+                if obj_filter.get('ipv4addr'):
+                    test_obj_filter = {'mac': obj_filter['mac'], 'ipv4addr': obj_filter['ipv4addr']}
+                else:
+                    test_obj_filter = {'mac': obj_filter['mac']}
             elif (ib_obj_type == NIOS_IPV6_FIXED_ADDRESS and 'duid' in obj_filter):
                 # Include both duid and ipv6addr to uniquely identify the fixed address.
-                test_obj_filter = dict([['duid', obj_filter['duid']], ['ipv6addr', obj_filter['ipv6addr']]])
+                # Guard against ipv6addr being absent for the same reason as IPv4.
+                if obj_filter.get('ipv6addr'):
+                    test_obj_filter = {'duid': obj_filter['duid'], 'ipv6addr': obj_filter['ipv6addr']}
+                else:
+                    test_obj_filter = {'duid': obj_filter['duid']}
             elif (ib_obj_type == NIOS_CNAME_RECORD):
                 test_obj_filter = dict([('name', obj_filter['name']), ('view', obj_filter['view'])])
             elif (ib_obj_type == NIOS_A_RECORD):

--- a/plugins/module_utils/api.py
+++ b/plugins/module_utils/api.py
@@ -1080,9 +1080,14 @@ class WapiModule(WapiBase):
                 else:
                     test_obj_filter = dict([('name', name), ('view', _view)])
             elif (ib_obj_type == NIOS_IPV4_FIXED_ADDRESS and 'mac' in obj_filter):
-                test_obj_filter = dict([['mac', obj_filter['mac']]])
+                # Include both mac and ipv4addr to uniquely identify the fixed address.
+                # Searching by mac alone returns all fixed addresses with that mac across
+                # all networks, which can cause the wrong record to be deleted or no match
+                # to be found (silent no-op on state=absent).
+                test_obj_filter = dict([['mac', obj_filter['mac']], ['ipv4addr', obj_filter['ipv4addr']]])
             elif (ib_obj_type == NIOS_IPV6_FIXED_ADDRESS and 'duid' in obj_filter):
-                test_obj_filter = dict([['duid', obj_filter['duid']]])
+                # Include both duid and ipv6addr to uniquely identify the fixed address.
+                test_obj_filter = dict([['duid', obj_filter['duid']], ['ipv6addr', obj_filter['ipv6addr']]])
             elif (ib_obj_type == NIOS_CNAME_RECORD):
                 test_obj_filter = dict([('name', obj_filter['name']), ('view', obj_filter['view'])])
             elif (ib_obj_type == NIOS_A_RECORD):

--- a/plugins/modules/nios_fixed_address.py
+++ b/plugins/modules/nios_fixed_address.py
@@ -231,6 +231,11 @@ def options(module):
     # options-router-templates, broadcast-address-offset, dhcp6.name-servers don't have any associated number
     special_num = [3, 6, 15, 28, 51]
     options = list()
+    if module.params.get('options') is None:
+        # options was not provided by the user; return None so WapiModule.run()
+        # omits the field from proposed_object entirely and avoids unintentionally
+        # clearing existing DHCP options on an update.
+        return None
     if not module.params['options']:
         return options
     for item in module.params['options']:

--- a/plugins/modules/nios_fixed_address.py
+++ b/plugins/modules/nios_fixed_address.py
@@ -231,6 +231,8 @@ def options(module):
     # options-router-templates, broadcast-address-offset, dhcp6.name-servers don't have any associated number
     special_num = [3, 6, 15, 28, 51]
     options = list()
+    if not module.params['options']:
+        return options
     for item in module.params['options']:
         opt = dict([(k, v) for k, v in item.items() if v is not None])
         if 'name' not in opt and 'num' not in opt:

--- a/tests/unit/plugins/modules/test_nios_fixed_address.py
+++ b/tests/unit/plugins/modules/test_nios_fixed_address.py
@@ -153,7 +153,99 @@ class TestNiosFixedAddressModule(TestNiosModule):
         self.assertTrue(res['changed'])
         wapi.delete_object.assert_called_once_with(ref)
 
-    def test_nios_fixed_address_ipv6_create(self):
+    # ------------------------------------------------------------------
+    # Tests for issue #114: state=absent uniquely identifies fixed address
+    # ------------------------------------------------------------------
+
+    def test_nios_fixed_address_ipv4_remove_uses_ip_in_filter(self):
+        """get_object must be called with mac AND ipv4addr so that the correct
+        fixed address is targeted when multiple records share the same MAC."""
+        self.module.params = {'provider': None, 'state': 'absent', 'name': 'test_fa',
+                              'ipv4addr': '192.168.10.1', 'mac': '08:6d:41:e8:fd:e8',
+                              'network': '192.168.10.0/24', 'network_view': 'default',
+                              'comment': None, 'extattrs': None}
+
+        ref = "fixedaddress/ZG5z:192.168.10.1/default"
+        test_object = [{
+            "name": "test_fa",
+            "_ref": ref,
+            "ipv4addr": "192.168.10.1",
+            "mac": "08:6d:41:e8:fd:e8",
+            "network": "192.168.10.0/24",
+            "network_view": "default",
+            "extattrs": {}
+        }]
+
+        test_spec = {
+            "name": {},
+            "ipv4addr": {"ib_req": True},
+            "mac": {"ib_req": True},
+            "network": {"ib_req": True},
+            "network_view": {},
+            "comment": {},
+            "extattrs": {}
+        }
+
+        wapi = self._get_wapi(test_object)
+        res = wapi.run('fixedaddress', test_spec)
+
+        self.assertTrue(res['changed'])
+        wapi.delete_object.assert_called_once_with(ref)
+        # Verify the lookup used both mac and ipv4addr
+        call_filter = wapi.get_object.call_args[0][1]
+        self.assertEqual(call_filter.get('mac'), '08:6d:41:e8:fd:e8')
+        self.assertEqual(call_filter.get('ipv4addr'), '192.168.10.1')
+
+    def test_nios_fixed_address_ipv4_remove_mac_only_fallback(self):
+        """When ipv4addr is absent from obj_filter, fall back to mac-only search
+        instead of raising KeyError."""
+        self.module.params = {'provider': None, 'state': 'absent', 'name': 'test_fa',
+                              'mac': '08:6d:41:e8:fd:e8',
+                              'network': '192.168.10.0/24', 'network_view': 'default',
+                              'comment': None, 'extattrs': None}
+
+        ref = "fixedaddress/ZG5z:192.168.10.5/default"
+        test_object = [{
+            "name": "test_fa",
+            "_ref": ref,
+            "mac": "08:6d:41:e8:fd:e8",
+            "network": "192.168.10.0/24",
+            "network_view": "default",
+            "extattrs": {}
+        }]
+
+        test_spec = {
+            "name": {},
+            "mac": {"ib_req": True},
+            "network": {"ib_req": True},
+            "network_view": {},
+            "comment": {},
+            "extattrs": {}
+        }
+
+        wapi = self._get_wapi(test_object)
+        res = wapi.run('fixedaddress', test_spec)
+
+        self.assertTrue(res['changed'])
+        wapi.delete_object.assert_called_once_with(ref)
+        # Verify no KeyError: lookup used mac only
+        call_filter = wapi.get_object.call_args[0][1]
+        self.assertEqual(call_filter.get('mac'), '08:6d:41:e8:fd:e8')
+        self.assertNotIn('ipv4addr', call_filter)
+
+    def test_nios_fixed_address_options_none_returns_none(self):
+        """options() must return None (not []) when options param is not set,
+        so WapiModule.run omits the field from proposed_object entirely and
+        does not accidentally clear existing DHCP options on update."""
+        self.module.params = {'options': None}
+        result = nios_fixed_address.options(self.module)
+        self.assertIsNone(result)
+
+    def test_nios_fixed_address_options_empty_list_returns_empty_list(self):
+        """options() returns [] when options param is explicitly set to []."""
+        self.module.params = {'options': []}
+        result = nios_fixed_address.options(self.module)
+        self.assertEqual(result, [])
         self.module.params = {'provider': None, 'state': 'present', 'name': 'test_fa', 'ipaddr': 'fe80::1/10', 'mac': '08:6d:41:e8:fd:e8',
                               'network': 'fe80::/64', 'network_view': 'default', 'comment': None, 'extattrs': None}
 


### PR DESCRIPTION
Two bugs fixed:

1. Search filter included only MAC (IPv4) or DUID (IPv6), causing state=absent to silently no-op when WAPI returns no match or multiple matches. Fix: include ipv4addr/ipv6addr in the search filter alongside mac/duid to uniquely identify the target fixed address.

2. options() transform function crashed with TypeError when options param is not specified (None is not iterable). Fix: return early if module.params['options'] is falsy.