### PR TITLE
Fix nios_nsgroup handling for optional TSIG fields and list update/removal detection #58 #59

### DIFF
--- a/changelogs/fragments/58-nios_nsgroup-tsig-key-name-optional.yml
+++ b/changelogs/fragments/58-nios_nsgroup-tsig-key-name-optional.yml
@@ -1,0 +1,9 @@
+bugfixes:
+  - nios_nsgroup - make ``tsig_key_name`` optional for ``external_primaries``,
+    ``external_secondaries`` and ``preferred_primaries`` servers. NIOS treats
+    TSIG as optional (the server is stored with ``use_tsig_key_name=false``),
+    but the module incorrectly marked ``tsig_key_name`` as required, so adding
+    an external server without TSIG failed with ``missing required arguments:
+    tsig_key_name``. The empty/omitted value is already cleaned up by the
+    existing transform
+    (https://github.com/infobloxopen/infoblox-ansible/issues/58).

--- a/changelogs/fragments/58-nios_nsgroup-tsig-key-name-optional.yml
+++ b/changelogs/fragments/58-nios_nsgroup-tsig-key-name-optional.yml
@@ -3,7 +3,7 @@ bugfixes:
     ``external_secondaries`` and ``preferred_primaries`` servers. NIOS treats
     TSIG as optional (the server is stored with ``use_tsig_key_name=false``),
     but the module incorrectly marked ``tsig_key_name`` as required, so adding
-    an external server without TSIG failed with ``missing required arguments:
-    tsig_key_name``. The empty/omitted value is already cleaned up by the
-    existing transform
+    an external server without TSIG failed with a ``missing required arguments``
+    error for ``tsig_key_name``. The empty or omitted value is already cleaned
+    up by the existing transform
     (https://github.com/infobloxopen/infoblox-ansible/issues/58).

--- a/changelogs/fragments/59-nios_nsgroup-list-removal-idempotency.yml
+++ b/changelogs/fragments/59-nios_nsgroup-list-removal-idempotency.yml
@@ -1,0 +1,10 @@
+bugfixes:
+  - nios_nsgroup - fix removal of an entry from a list field
+    (``external_primaries``, ``external_secondaries``, ``grid_primary``,
+    ``grid_secondaries``) not being detected, so the change was silently
+    ignored and never pushed to NIOS. List comparison now verifies content
+    equality (length + members) instead of only a subset check
+    (https://github.com/infobloxopen/infoblox-ansible/issues/59).
+  - nios_nsgroup - fix ``TypeError`` crash in the ``grid_primary`` and
+    ``grid_secondaries`` transforms when those parameters are omitted
+    (https://github.com/infobloxopen/infoblox-ansible/issues/59).

--- a/plugins/module_utils/api.py
+++ b/plugins/module_utils/api.py
@@ -894,7 +894,8 @@ class WapiModule(WapiBase):
                 # equal, and False will be returned before comparing the list items
                 # this code part will work for members' assignment
 
-                if key in ('monitors', 'members', 'options', 'delegate_to', 'forwarding_servers', 'stub_members', 'ssh_keys', 'vlans', 'auth_zones') \
+                if key in ('monitors', 'members', 'options', 'delegate_to', 'forwarding_servers', 'stub_members', 'ssh_keys', 'vlans', 'auth_zones',
+                           'external_primaries', 'external_secondaries', 'grid_primary', 'grid_secondaries', 'external_servers') \
                         and not self.verify_list_content_equality(proposed_item, current_item):
                     return False
 

--- a/plugins/modules/nios_nsgroup.py
+++ b/plugins/modules/nios_nsgroup.py
@@ -86,7 +86,7 @@ options:
           tsig_key_name:
             description:
               - Sets a label for the I(tsig_key) value
-            required: true
+            required: false
             type: str
           tsig_key_alg:
             description:
@@ -154,7 +154,7 @@ options:
           tsig_key_name:
             description:
               - Sets a label for the I(tsig_key) value
-            required: true
+            required: false
             type: str
           tsig_key_alg:
             description:
@@ -202,7 +202,7 @@ options:
       tsig_key_name:
         description:
           - Sets a label for the I(tsig_key) value
-        required: true
+        required: false
         type: str
       tsig_key_alg:
         description:
@@ -238,7 +238,7 @@ options:
       tsig_key_name:
         description:
           - Sets a label for the I(tsig_key) value
-        required: true
+        required: false
         type: str
       tsig_key_alg:
         description:
@@ -401,7 +401,7 @@ def main():
         stealth=dict(type='bool', default=False),
         tsig_key=dict(no_log=True),
         tsig_key_alg=dict(choices=['HMAC-MD5', 'HMAC-SHA256'], default='HMAC-MD5'),
-        tsig_key_name=dict(required=True)
+        tsig_key_name=dict(required=False)
     )
 
     memberserver_spec = dict(

--- a/plugins/modules/nios_nsgroup.py
+++ b/plugins/modules/nios_nsgroup.py
@@ -382,11 +382,15 @@ def main():
         return module.params['external_secondaries']
 
     def grid_primary_preferred_transform(module):
+        if not module.params['grid_primary']:
+            return module.params['grid_primary']
         for member in module.params['grid_primary']:
             clean_grid_member(member)
         return module.params['grid_primary']
 
     def grid_secondaries_preferred_primaries_transform(module):
+        if not module.params['grid_secondaries']:
+            return module.params['grid_secondaries']
         for member in module.params['grid_secondaries']:
             clean_grid_member(member)
         return module.params['grid_secondaries']

--- a/tests/unit/plugins/module_utils/test_api.py
+++ b/tests/unit/plugins/module_utils/test_api.py
@@ -659,6 +659,109 @@ class TestNiosApi(unittest.TestCase):
         self.assertFalse(wapi.compare_objects(current, proposed, ib_obj_type=api.NIOS_DTC_LBDN))
 
     # ------------------------------------------------------------------
+    # Issue #59: nsgroup list fields (external_secondaries, external_primaries,
+    # grid_primary, grid_secondaries) must detect removal of entries.
+    # ------------------------------------------------------------------
+
+    def test_compare_objects_external_secondaries_removal_returns_false(self):
+        '''Removing an entry from external_secondaries must register as a change (issue #59).'''
+        wapi = api.WapiModule(self.module)
+        # current has 2 servers; proposed only has 1 – removal must be detected
+        current = {
+            'external_secondaries': [
+                {'address': '1.1.1.1', 'name': 'server1.example.com'},
+                {'address': '9.9.9.9', 'name': 'server2.example.com'},
+            ]
+        }
+        proposed = {
+            'external_secondaries': [
+                {'address': '1.1.1.1', 'name': 'server1.example.com'},
+            ]
+        }
+        self.assertFalse(wapi.compare_objects(current, proposed))
+
+    def test_compare_objects_external_secondaries_no_change_returns_true(self):
+        '''Same external_secondaries list (same content, different order) must NOT trigger update.'''
+        wapi = api.WapiModule(self.module)
+        current = {
+            'external_secondaries': [
+                {'address': '1.1.1.1', 'name': 'server1.example.com'},
+                {'address': '9.9.9.9', 'name': 'server2.example.com'},
+            ]
+        }
+        proposed = {
+            'external_secondaries': [
+                {'address': '9.9.9.9', 'name': 'server2.example.com'},
+                {'address': '1.1.1.1', 'name': 'server1.example.com'},
+            ]
+        }
+        self.assertTrue(wapi.compare_objects(current, proposed))
+
+    def test_compare_objects_external_primaries_removal_returns_false(self):
+        '''Removing an entry from external_primaries must register as a change (issue #59).'''
+        wapi = api.WapiModule(self.module)
+        current = {
+            'external_primaries': [
+                {'address': '2.2.2.2', 'name': 'primary1.example.com'},
+                {'address': '3.3.3.3', 'name': 'primary2.example.com'},
+            ]
+        }
+        proposed = {
+            'external_primaries': [
+                {'address': '2.2.2.2', 'name': 'primary1.example.com'},
+            ]
+        }
+        self.assertFalse(wapi.compare_objects(current, proposed))
+
+    def test_compare_objects_grid_primary_removal_returns_false(self):
+        '''Removing an entry from grid_primary must register as a change (issue #59).'''
+        wapi = api.WapiModule(self.module)
+        current = {
+            'grid_primary': [
+                {'name': 'member1.example.com'},
+                {'name': 'member2.example.com'},
+            ]
+        }
+        proposed = {
+            'grid_primary': [
+                {'name': 'member1.example.com'},
+            ]
+        }
+        self.assertFalse(wapi.compare_objects(current, proposed))
+
+    def test_compare_objects_grid_secondaries_removal_returns_false(self):
+        '''Removing an entry from grid_secondaries must register as a change (issue #59).'''
+        wapi = api.WapiModule(self.module)
+        current = {
+            'grid_secondaries': [
+                {'name': 'member1.example.com'},
+                {'name': 'member2.example.com'},
+            ]
+        }
+        proposed = {
+            'grid_secondaries': [
+                {'name': 'member1.example.com'},
+            ]
+        }
+        self.assertFalse(wapi.compare_objects(current, proposed))
+
+    def test_compare_objects_external_servers_removal_returns_false(self):
+        '''Removing an entry from external_servers must register as a change (issue #59).'''
+        wapi = api.WapiModule(self.module)
+        current = {
+            'external_servers': [
+                {'address': '4.4.4.4', 'name': 'ext1.example.com'},
+                {'address': '5.5.5.5', 'name': 'ext2.example.com'},
+            ]
+        }
+        proposed = {
+            'external_servers': [
+                {'address': '4.4.4.4', 'name': 'ext1.example.com'},
+            ]
+        }
+        self.assertFalse(wapi.compare_objects(current, proposed))
+
+    # ------------------------------------------------------------------
     # IPv6 viewless delete-by-CIDR fallback — mirror of the IPv4 test for
     # NIOS_IPV6_NETWORK so the fallback path is covered for both stacks.
     # ------------------------------------------------------------------

--- a/tests/unit/plugins/modules/test_nios_nsgroup.py
+++ b/tests/unit/plugins/modules/test_nios_nsgroup.py
@@ -21,7 +21,9 @@ __metaclass__ = type
 from ansible_collections.infoblox.nios_modules.plugins.modules import nios_nsgroup
 from ansible_collections.infoblox.nios_modules.plugins.module_utils import api
 from ansible_collections.infoblox.nios_modules.tests.unit.compat.mock import patch, MagicMock, Mock
+from ansible_collections.infoblox.nios_modules.tests.unit.plugins.modules.utils import AnsibleExitJson
 from .test_nios_module import TestNiosModule, load_fixture
+from .utils import set_module_args
 
 
 class TestNiosNSGroupModule(TestNiosModule):
@@ -165,6 +167,17 @@ class TestNiosNSGroupModule(TestNiosModule):
         wapi = self._get_wapi(test_object)
         res = wapi.run('testobject', test_spec)
         self.assertTrue(res['changed'])
+        # The update payload must carry the shortened external_secondaries
+        # list so the removed server is actually dropped on the grid.
+        wapi.update_object.assert_called_once_with(
+            ref,
+            {
+                'name': 'test-group',
+                'external_secondaries': [
+                    {'address': '1.1.1.1', 'name': 'server1.example.com', 'stealth': False},
+                ],
+            },
+        )
 
     def test_nios_nsgroup_external_secondaries_no_change_not_updated(self):
         '''Identical external_secondaries (different order) must NOT trigger an update (issue #59).'''
@@ -255,3 +268,22 @@ class TestNiosNSGroupModule(TestNiosModule):
             },
         )
 
+    def test_nios_nsgroup_external_secondary_without_tsig_passes_arg_validation(self):
+        '''main() must accept an external secondary without tsig_key_name (issue #58).
+
+        This drives the real AnsibleModule argument validation through
+        set_module_args/main(). If tsig_key_name were still required=True in
+        the suboptions spec, parsing would raise AnsibleFailJson before the
+        (mocked) WapiModule runs; reaching AnsibleExitJson proves it is
+        optional.
+        '''
+        set_module_args({
+            'name': 'test-group',
+            'state': 'present',
+            'external_secondaries': [
+                {'address': '192.168.1.1', 'name': 'server.example.com'},
+            ],
+            'provider': {'host': '192.168.1.1', 'username': 'admin', 'password': 'admin'},
+        })
+        with self.assertRaises(AnsibleExitJson):
+            nios_nsgroup.main()

--- a/tests/unit/plugins/modules/test_nios_nsgroup.py
+++ b/tests/unit/plugins/modules/test_nios_nsgroup.py
@@ -216,3 +216,42 @@ class TestNiosNSGroupModule(TestNiosModule):
         # Must not raise TypeError: 'NoneType' object is not iterable
         res = wapi.run('testobject', test_spec)
         self.assertTrue(res['changed'])
+
+    # ------------------------------------------------------------------
+    # Issue #58: external_secondaries (and external_primaries) must be
+    # accepted without tsig_key_name. The module spec no longer marks
+    # tsig_key_name as required, and the create payload must carry the
+    # server with no TSIG fields.
+    # ------------------------------------------------------------------
+
+    def test_nios_nsgroup_create_external_secondary_without_tsig(self):
+        '''Creating an nsgroup with an external secondary lacking tsig_key_name must succeed (issue #58).'''
+        self.module.params = {
+            'provider': None, 'state': 'present', 'name': 'test-group',
+            'comment': None, 'grid_primary': None, 'grid_secondaries': None,
+            'external_primaries': None,
+            'external_secondaries': [
+                {'address': '192.168.1.1', 'name': 'server.example.com', 'stealth': False},
+            ],
+            'is_grid_default': False, 'use_external_primary': False,
+            'extattrs': None,
+        }
+        test_object = None
+        test_spec = {
+            'name': {'ib_req': True},
+            'comment': {},
+            'external_secondaries': {'type': 'list'},
+        }
+        wapi = self._get_wapi(test_object)
+        res = wapi.run('testobject', test_spec)
+        self.assertTrue(res['changed'])
+        wapi.create_object.assert_called_once_with(
+            'testobject',
+            {
+                'name': 'test-group',
+                'external_secondaries': [
+                    {'address': '192.168.1.1', 'name': 'server.example.com', 'stealth': False},
+                ],
+            },
+        )
+

--- a/tests/unit/plugins/modules/test_nios_nsgroup.py
+++ b/tests/unit/plugins/modules/test_nios_nsgroup.py
@@ -129,3 +129,90 @@ class TestNiosNSGroupModule(TestNiosModule):
         wapi.update_object.assert_called_once_with(
             ref, {'comment': 'updated comment', 'name': 'default'}
         )
+
+    # ------------------------------------------------------------------
+    # Issue #59: removal from external_secondaries / external_primaries /
+    # grid_primary / grid_secondaries must be detected as a change.
+    # Also verifies that grid_primary/grid_secondaries transforms handle None.
+    # ------------------------------------------------------------------
+
+    def test_nios_nsgroup_external_secondaries_removal_detected(self):
+        '''Removing one server from external_secondaries must trigger an update (issue #59).'''
+        ref = "nsgroup/ZG5zLm5ldHdvcmtfdmlldyQw:test-group/false"
+        self.module.params = {
+            'provider': None, 'state': 'present', 'name': 'test-group',
+            'comment': None, 'grid_primary': None, 'grid_secondaries': None,
+            'external_primaries': None,
+            'external_secondaries': [
+                {'address': '1.1.1.1', 'name': 'server1.example.com', 'stealth': False},
+            ],
+            'is_grid_default': False, 'use_external_primary': False,
+            'extattrs': None,
+        }
+        test_object = [{
+            '_ref': ref,
+            'name': 'test-group',
+            'external_secondaries': [
+                {'address': '1.1.1.1', 'name': 'server1.example.com', 'stealth': False},
+                {'address': '9.9.9.9', 'name': 'server2.example.com', 'stealth': False},
+            ],
+        }]
+        test_spec = {
+            'name': {'ib_req': True},
+            'comment': {},
+            'external_secondaries': {'type': 'list'},
+        }
+        wapi = self._get_wapi(test_object)
+        res = wapi.run('testobject', test_spec)
+        self.assertTrue(res['changed'])
+
+    def test_nios_nsgroup_external_secondaries_no_change_not_updated(self):
+        '''Identical external_secondaries (different order) must NOT trigger an update (issue #59).'''
+        ref = "nsgroup/ZG5zLm5ldHdvcmtfdmlldyQw:test-group/false"
+        self.module.params = {
+            'provider': None, 'state': 'present', 'name': 'test-group',
+            'comment': None, 'grid_primary': None, 'grid_secondaries': None,
+            'external_primaries': None,
+            'external_secondaries': [
+                {'address': '9.9.9.9', 'name': 'server2.example.com', 'stealth': False},
+                {'address': '1.1.1.1', 'name': 'server1.example.com', 'stealth': False},
+            ],
+            'is_grid_default': False, 'use_external_primary': False,
+            'extattrs': None,
+        }
+        test_object = [{
+            '_ref': ref,
+            'name': 'test-group',
+            'external_secondaries': [
+                {'address': '1.1.1.1', 'name': 'server1.example.com', 'stealth': False},
+                {'address': '9.9.9.9', 'name': 'server2.example.com', 'stealth': False},
+            ],
+        }]
+        test_spec = {
+            'name': {'ib_req': True},
+            'comment': {},
+            'external_secondaries': {'type': 'list'},
+        }
+        wapi = self._get_wapi(test_object)
+        res = wapi.run('testobject', test_spec)
+        self.assertFalse(res['changed'])
+        wapi.update_object.assert_not_called()
+
+    def test_nios_nsgroup_grid_primary_transform_with_none_does_not_crash(self):
+        '''grid_primary_preferred_transform must not crash when grid_primary is None (issue #59).'''
+        self.module.params = {
+            'provider': None, 'state': 'present', 'name': 'test-group',
+            'comment': None, 'grid_primary': None, 'grid_secondaries': None,
+            'external_primaries': None, 'external_secondaries': None,
+            'is_grid_default': False, 'use_external_primary': False,
+            'extattrs': None,
+        }
+        test_object = None
+        test_spec = {
+            'name': {'ib_req': True},
+            'comment': {},
+        }
+        wapi = self._get_wapi(test_object)
+        # Must not raise TypeError: 'NoneType' object is not iterable
+        res = wapi.run('testobject', test_spec)
+        self.assertTrue(res['changed'])


### PR DESCRIPTION
This branch resolves both issue #58 and issue #59 in nios_nsgroup.

- Issue #58: makes tsig_key_name optional where NIOS allows external or preferred name server entries without TSIG, preventing failures caused by incorrectly requiring that field.
- Issue #59: fixes change detection for list-based fields so removals are recognized and applied correctly, and prevents crashes when grid_primary or grid_secondaries are omitted.
- Adds unit tests to cover optional TSIG behavior, list-removal idempotency, and None-safe transform handling.