### PR TITLE
Fix nios_inventory confusing error on WAPI failures (issue #223)

### DIFF
--- a/changelogs/fragments/223-nios_inventory-handle-exception.yml
+++ b/changelogs/fragments/223-nios_inventory-handle-exception.yml
@@ -1,0 +1,9 @@
+---
+bugfixes:
+  - nios_inventory - surface a meaningful error when the Infoblox Grid cannot
+    be queried (for example wrong username or password, unreachable host, or a
+    connection timeout). Previously the ``WapiInventory`` class did not define
+    a ``handle_exception`` method, so the dynamic attribute lookup on
+    ``WapiBase`` dispatched the call to the underlying ``Connector`` and the
+    plugin failed with the confusing ``'Connector' object has no attribute
+    'handle_exception'`` message instead of the actual cause (issue #223).

--- a/changelogs/fragments/223-nios_inventory-handle-exception.yml
+++ b/changelogs/fragments/223-nios_inventory-handle-exception.yml
@@ -6,4 +6,8 @@ bugfixes:
     a ``handle_exception`` method, so the dynamic attribute lookup on
     ``WapiBase`` dispatched the call to the underlying ``Connector`` and the
     plugin failed with the confusing ``'Connector' object has no attribute
-    'handle_exception'`` message instead of the actual cause (issue #223).
+    'handle_exception'`` message instead of the actual cause. Connection level
+    failures now raise an ``Unable to connect to Infoblox NIOS host`` error
+    while other query failures raise a distinct ``Failed to query Infoblox
+    NIOS host`` error so unrelated problems are not mislabeled as connectivity
+    issues (issue #223).

--- a/plugins/inventory/nios_inventory.py
+++ b/plugins/inventory/nios_inventory.py
@@ -71,6 +71,7 @@ from ansible.plugins.inventory import BaseInventoryPlugin
 from ..module_utils.api import WapiInventory
 from ..module_utils.api import normalize_extattrs, flatten_extattrs
 from ansible.errors import AnsibleError
+from ansible.module_utils.common.text.converters import to_native
 
 
 class InventoryModule(BaseInventoryPlugin):
@@ -84,13 +85,20 @@ class InventoryModule(BaseInventoryPlugin):
                     'username': self.get_option('username'),
                     'password': self.get_option('password')}
 
-        wapi = WapiInventory(provider)
-
         host_filter = self.get_option('hostfilter')
         extattrs = normalize_extattrs(self.get_option('extattrs'))
         return_fields = ['name', 'view', 'extattrs', 'ipv4addrs']
 
-        hosts = wapi.get_object('record:host', host_filter, extattrs=extattrs, return_fields=return_fields) or []
+        try:
+            wapi = WapiInventory(provider)
+            hosts = wapi.get_object('record:host', host_filter, extattrs=extattrs, return_fields=return_fields) or []
+        except AnsibleError:
+            raise
+        except Exception as exc:
+            raise AnsibleError(
+                "Unable to connect to Infoblox NIOS host '%s': %s"
+                % (provider['host'], to_native(exc))
+            )
 
         if not hosts:
             raise AnsibleError("host record is not present")

--- a/plugins/inventory/nios_inventory.py
+++ b/plugins/inventory/nios_inventory.py
@@ -73,6 +73,18 @@ from ..module_utils.api import normalize_extattrs, flatten_extattrs
 from ansible.errors import AnsibleError
 from ansible.module_utils.common.text.converters import to_native
 
+try:
+    from infoblox_client.exceptions import InfobloxException, InfobloxConnectionError
+except ImportError:
+    # infoblox-client is a runtime requirement of the plugin. Define harmless
+    # placeholders so the module still imports (for example during sanity or
+    # documentation parsing) and the ``except`` clauses below remain valid.
+    class InfobloxException(Exception):
+        pass
+
+    class InfobloxConnectionError(Exception):
+        pass
+
 
 class InventoryModule(BaseInventoryPlugin):
     NAME = 'nios_inventory'
@@ -94,9 +106,21 @@ class InventoryModule(BaseInventoryPlugin):
             hosts = wapi.get_object('record:host', host_filter, extattrs=extattrs, return_fields=return_fields) or []
         except AnsibleError:
             raise
-        except Exception as exc:
+        except (InfobloxConnectionError, InfobloxException) as exc:
+            # Connection/WAPI level failures: host unreachable, refused,
+            # TLS/timeout, or any InfobloxException that was not re-wrapped by
+            # WapiInventory.handle_exception.
             raise AnsibleError(
                 "Unable to connect to Infoblox NIOS host '%s': %s"
+                % (provider['host'], to_native(exc))
+            ) from exc
+        except Exception as exc:
+            # handle_exception surfaces the real WAPI error text (for example
+            # wrong username or password) as a plain Exception; any other
+            # unexpected failure is reported here without being mislabeled as a
+            # connectivity problem.
+            raise AnsibleError(
+                "Failed to query Infoblox NIOS host '%s': %s"
                 % (provider['host'], to_native(exc))
             ) from exc
 

--- a/plugins/inventory/nios_inventory.py
+++ b/plugins/inventory/nios_inventory.py
@@ -98,7 +98,7 @@ class InventoryModule(BaseInventoryPlugin):
             raise AnsibleError(
                 "Unable to connect to Infoblox NIOS host '%s': %s"
                 % (provider['host'], to_native(exc))
-            )
+            ) from exc
 
         if not hosts:
             raise AnsibleError("host record is not present")

--- a/plugins/module_utils/api.py
+++ b/plugins/module_utils/api.py
@@ -327,8 +327,8 @@ class WapiInventory(WapiBase):
         '''
         response = getattr(exc, 'response', None) or {}
         if 'text' in response:
-            raise Exception(response['text'])
-        raise Exception(exc)
+            raise Exception(response['text']) from exc
+        raise Exception(exc) from exc
 
 
 class AnsibleError(Exception):

--- a/plugins/module_utils/api.py
+++ b/plugins/module_utils/api.py
@@ -313,8 +313,22 @@ class WapiLookup(WapiBase):
 
 
 class WapiInventory(WapiBase):
-    ''' Implements WapiBase for dynamic inventory script '''
-    pass
+    ''' Implements WapiBase for dynamic inventory plugin '''
+    def handle_exception(self, method_name, exc):
+        ''' Surface a meaningful error when a WAPI call fails.
+
+        Without this method the dynamic ``__getattr__`` on :class:`WapiBase`
+        resolves the ``handle_exception`` lookup to a ``partial`` wrapper, so
+        ``hasattr(self, 'handle_exception')`` in ``_invoke_method`` is always
+        True and the call is dispatched to the underlying ``Connector``. That
+        produced the misleading "'Connector' object has no attribute
+        'handle_exception'" error instead of the real cause (wrong username or
+        password, unreachable host, timeout, etc.).
+        '''
+        response = getattr(exc, 'response', None) or {}
+        if 'text' in response:
+            raise Exception(response['text'])
+        raise Exception(exc)
 
 
 class AnsibleError(Exception):

--- a/tests/unit/plugins/inventory/test_nios_inventory.py
+++ b/tests/unit/plugins/inventory/test_nios_inventory.py
@@ -1,0 +1,89 @@
+# (c) 2018 Red Hat, Inc.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+try:
+    from ansible_collections.infoblox.nios_modules.tests.unit.compat import unittest
+except ImportError:
+    import unittest
+from ansible_collections.infoblox.nios_modules.tests.unit.compat.mock import patch, MagicMock
+from ansible.errors import AnsibleError
+from infoblox_client.exceptions import InfobloxException, InfobloxConnectionError
+from ansible_collections.infoblox.nios_modules.plugins.inventory import nios_inventory
+
+
+class TestNiosInventoryParse(unittest.TestCase):
+    # ------------------------------------------------------------------
+    # Issue #223: parse() must distinguish connection/WAPI failures from
+    # other unexpected errors so unrelated problems are not mislabeled as
+    # connectivity issues.
+    # ------------------------------------------------------------------
+
+    def setUp(self):
+        super(TestNiosInventoryParse, self).setUp()
+        self.plugin = nios_inventory.InventoryModule()
+        self.plugin._read_config_data = MagicMock(name='_read_config_data')
+        self.plugin.inventory = MagicMock(name='inventory')
+        self._options = {
+            'host': 'blox.example.com',
+            'username': 'admin',
+            'password': 'secret',
+            'hostfilter': {},
+            'extattrs': {},
+        }
+        self.plugin.get_option = lambda name: self._options[name]
+
+    def _run_parse(self, get_object_side_effect):
+        wapi = MagicMock(name='WapiInventory')
+        wapi.get_object.side_effect = get_object_side_effect
+        with patch.object(nios_inventory.BaseInventoryPlugin, 'parse'), \
+                patch.object(nios_inventory, 'WapiInventory', return_value=wapi):
+            self.plugin.parse(MagicMock(), MagicMock(), '/path/to/inventory.yml')
+
+    def test_connection_error_reports_unable_to_connect(self):
+        '''InfobloxConnectionError must surface as an "Unable to connect" error.'''
+        exc = InfobloxConnectionError(reason='Connection refused')
+        with self.assertRaises(AnsibleError) as cm:
+            self._run_parse(exc)
+        msg = str(cm.exception)
+        self.assertIn("Unable to connect to Infoblox NIOS host 'blox.example.com'", msg)
+        self.assertIn('Connection refused', msg)
+
+    def test_infoblox_exception_reports_unable_to_connect(self):
+        '''A raw InfobloxException must also map to the connect message.'''
+        exc = InfobloxException(response={'text': 'bad credentials'})
+        with self.assertRaises(AnsibleError) as cm:
+            self._run_parse(exc)
+        self.assertIn(
+            "Unable to connect to Infoblox NIOS host 'blox.example.com'",
+            str(cm.exception),
+        )
+
+    def test_wrapped_wapi_error_reports_failed_to_query(self):
+        '''handle_exception surfaces WAPI text as a plain Exception, which must
+        be reported as a query failure, not a connectivity issue.'''
+        exc = Exception('authentication failure')
+        with self.assertRaises(AnsibleError) as cm:
+            self._run_parse(exc)
+        msg = str(cm.exception)
+        self.assertIn("Failed to query Infoblox NIOS host 'blox.example.com'", msg)
+        self.assertIn('authentication failure', msg)
+
+    def test_unexpected_error_reports_failed_to_query(self):
+        '''An unrelated runtime error must use the generic query message.'''
+        exc = KeyError('boom')
+        with self.assertRaises(AnsibleError) as cm:
+            self._run_parse(exc)
+        self.assertIn(
+            "Failed to query Infoblox NIOS host 'blox.example.com'",
+            str(cm.exception),
+        )
+
+    def test_ansible_error_is_propagated_unchanged(self):
+        '''An AnsibleError raised inside the try block must propagate as-is.'''
+        exc = AnsibleError('original ansible error')
+        with self.assertRaises(AnsibleError) as cm:
+            self._run_parse(exc)
+        self.assertIn('original ansible error', str(cm.exception))

--- a/tests/unit/plugins/module_utils/test_api.py
+++ b/tests/unit/plugins/module_utils/test_api.py
@@ -592,6 +592,60 @@ class TestNiosApi(unittest.TestCase):
         self.assertEqual(str(cm.exception), 'wapi said no')
 
     # ------------------------------------------------------------------
+    # Issue #223 — WapiInventory must surface a meaningful error.
+    #
+    # WapiInventory historically lacked handle_exception. Because
+    # WapiBase.__getattr__ returns a partial for any non-underscore
+    # attribute, hasattr(self, 'handle_exception') in _invoke_method was
+    # always True, so the call got dispatched to the Connector producing the
+    # misleading "'Connector' object has no attribute 'handle_exception'"
+    # error instead of the real cause (bad credentials, unreachable host).
+    # ------------------------------------------------------------------
+    def test_wapi_inventory_has_handle_exception(self):
+        '''WapiInventory must define its own handle_exception (issue #223).'''
+        self.assertIn('handle_exception', api.WapiInventory.__dict__)
+
+    def test_wapi_inventory_handle_exception_text_path(self):
+        '''WapiInventory should raise Exception(text) when response has text.'''
+        inventory = api.WapiInventory({})
+        exc = Exception('original')
+        exc.response = {'text': 'authentication failure'}
+
+        with self.assertRaises(Exception) as cm:
+            inventory.handle_exception('get_object', exc)
+        self.assertNotIsInstance(cm.exception, AttributeError)
+        self.assertEqual(str(cm.exception), 'authentication failure')
+
+    def test_wapi_inventory_handle_exception_no_response_falls_back(self):
+        '''WapiInventory must wrap exc when response is missing/None.'''
+        inventory = api.WapiInventory({})
+        exc = Exception('host unreachable')
+        exc.response = None
+
+        with self.assertRaises(Exception) as cm:
+            inventory.handle_exception('get_object', exc)
+        self.assertNotIsInstance(cm.exception, AttributeError)
+        self.assertIn('host unreachable', str(cm.exception))
+
+    def test_wapi_inventory_invoke_method_uses_handle_exception(self):
+        '''An InfobloxException from a WAPI call must route through
+        WapiInventory.handle_exception, not the Connector (issue #223).'''
+        inventory = api.WapiInventory({})
+
+        exc = api.InfobloxException(response={'text': 'bad credentials'})
+
+        connector = MagicMock(name='Connector')
+        connector.get_object.side_effect = exc
+        inventory.connector = connector
+
+        with self.assertRaises(Exception) as cm:
+            inventory.get_object('record:host', {})
+        # Must be the meaningful WAPI message, NOT the confusing AttributeError
+        # about the Connector lacking handle_exception.
+        self.assertNotIsInstance(cm.exception, AttributeError)
+        self.assertEqual(str(cm.exception), 'bad credentials')
+
+    # ------------------------------------------------------------------
     # convert_vlans_to_struct — direct unit tests for the new helper.
     # ------------------------------------------------------------------
 


### PR DESCRIPTION
WapiInventory lacked a handle_exception method. Because WapiBase.__getattr__ returns a partial for any non-underscore attribute, hasattr(self, 'handle_exception') in _invoke_method was always True, so the call was dispatched to the underlying Connector, producing the misleading "'Connector' object has no attribute 'handle_exception'" error instead of the real cause (wrong credentials, unreachable host, timeout, etc.).

- api.py: add WapiInventory.handle_exception to surface the actual WAPI error text for InfobloxException-derived failures.
- nios_inventory.py: wrap the connection and get_object call in parse() so all failure modes (including InfobloxConnectionError, which extends BaseExc and bypasses _invoke_method) raise a clear AnsibleError.
- Add unit tests covering handle_exception presence, text path, no-response fallback, and _invoke_method routing.
- Add changelog fragment.