### PR TITLE
Fix DTC topology rules no longer working as of WAPI 2.14

### DIFF
--- a/changelogs/fragments/342-nios_dtc_topology-destination_link-deprecation.yml
+++ b/changelogs/fragments/342-nios_dtc_topology-destination_link-deprecation.yml
@@ -1,0 +1,6 @@
+---
+bugfixes:
+  - nios_dtc_topology module - ``destination_link`` has been replaced by the
+    new ``destination`` struct array. As of WAPI 2.14 support for the former
+    has been dropped. This change adds support for the new field.
+    (https://github.com/infobloxopen/infoblox-ansible/pull/342)

--- a/plugins/module_utils/api.py
+++ b/plugins/module_utils/api.py
@@ -482,6 +482,15 @@ class WapiModule(WapiBase):
                 current_object = ib_obj_ref[0]
             if 'extattrs' in current_object:
                 current_object['extattrs'] = flatten_extattrs(current_object['extattrs'])
+            if ib_obj_type == NIOS_DTC_TOPOLOGY and 'rules' in current_object:
+                for rule in current_object['rules']:
+                    rule.pop('_ref', None)
+                    rule.pop('uuid', None)
+                    if 'destination' in rule:
+                        for dest in rule['destination']:
+                            dl = dest.get('destination_link')
+                            if isinstance(dl, dict):
+                                dest['destination_link'] = dl['_ref']
             if current_object.get('_ref'):
                 ref = current_object.pop('_ref')
         else:
@@ -673,10 +682,12 @@ class WapiModule(WapiBase):
                         # WAPI always reset the use_for_ea_inheritance for each update operation
                         # Handle use_for_ea_inheritance flag changes for IPv4addr in a host record
                         # Fetch the updated reference of host to avoid drift.
-                        host_ref = self.connector.get_object(obj_type=str(res), return_fields=['ipv4addrs'])
+                        res_ref = res['_ref'] if isinstance(res, dict) else res
+                        host_ref = self.connector.get_object(obj_type=str(res_ref), return_fields=['ipv4addrs'])
                         if host_ref and 'ipv4addrs' in host_ref:
-                            # Create a dictionary for quick lookups
-                            ref_dict = {obj['ipv4addr']: obj['_ref'] for obj in host_ref['ipv4addrs']}
+                            # Create a dictionary for quick lookups.
+                            ref_dict = {obj['ipv4addr']: obj['_ref'] for obj in host_ref['ipv4addrs']
+                                        if 'ipv4addr' in obj and '_ref' in obj}
                             sorted_ipv4addrs = sorted(proposed_object['ipv4addrs'], key=lambda x: x.get('use_for_ea_inheritance', False))
                             for proposed in sorted_ipv4addrs:
                                 ipv4addr = proposed['ipv4addr']
@@ -708,7 +719,7 @@ class WapiModule(WapiBase):
                 and result.get('changed')
                 and not self.module.check_mode
                 and ib_obj_type not in NIOS_RETURN_OBJECT_EXCLUDE):
-            target_ref = res if res else ref
+            target_ref = res['_ref'] if isinstance(res, dict) else (res if res else ref)
             if target_ref:
                 return_fields = sorted({
                     k for k in ib_spec.keys()
@@ -1160,6 +1171,11 @@ class WapiModule(WapiBase):
                 ]
                 return_fields.extend(ipv4addrs_return)
                 return_fields.extend(ipv6addrs_return)
+
+            if ib_obj_type == NIOS_DTC_TOPOLOGY:
+                return_fields.extend([
+                    'rules.dest_type', 'rules.destination', 'rules.return_type', 'rules.sources'
+                ])
 
             ib_obj = self.get_object(ib_obj_type, test_obj_filter.copy(), return_fields=return_fields)
 

--- a/plugins/modules/nios_dtc_topology.py
+++ b/plugins/modules/nios_dtc_topology.py
@@ -41,10 +41,20 @@ options:
           - POOL
           - SERVER
         required: true
-      destination_link:
+      destination:
         description:
-          - Configures the name of the destination DTC pool or DTC server.
-        type: str
+          - Configures the set of destinations.
+        type: list
+        elements: dict
+        suboptions:
+          destination_link:
+            description: The name of the destination DTC pool or DTC server.
+            type: str
+            required: true
+          priority:
+            description: Priority of this destination over the others
+            type: int
+            required: true
       return_type:
         description:
           - Configures the type of the DNS response for the rule.
@@ -119,14 +129,22 @@ EXAMPLES = '''
     name: a_topology
     rules:
       - dest_type: POOL
-        destination_link: web_pool1
+        destination:
+          - destination_link: web_pool1
+            priority: 1
+          - destination_link: web_pool2
+            priority: 2
         return_type: REGULAR
         sources:
           - source_op: IS
             source_type: EA0
             source_value: DC1
       - dest_type: POOL
-        destination_link: web_pool2
+        destination:
+          - destination_link: web_pool1
+            priority: 2
+          - destination_link: web_pool2
+            priority: 1
         return_type: REGULAR
         sources:
           - source_op: IS
@@ -182,26 +200,38 @@ def main():
             source_list.append(src)
         return source_list
 
+    def destination_transform(destinations, dest_type, module):
+        dest_list = list()
+        for dest in destinations:
+            if dest_type == 'POOL':
+                dest_obj = wapi.get_object('dtc:pool', {'name': dest['destination_link']})
+            else:
+                dest_obj = wapi.get_object('dtc:server', {'name': dest['destination_link']})
+            if not dest_obj:
+                module.fail_json(msg='destination_link %s does not exist' % dest['destination_link'])
+            dest_list.append({
+                'destination_link': dest_obj[0]['_ref'],
+                'priority': dest['priority']
+            })
+        return dest_list
+
     def rules_transform(module):
         rule_list = list()
-        dest_obj = None
 
         if not module.params['rules']:
             return rule_list
 
         for rule in module.params['rules']:
-            if rule['dest_type'] == 'POOL':
-                dest_obj = wapi.get_object('dtc:pool', {'name': rule['destination_link']})
-            else:
-                dest_obj = wapi.get_object('dtc:server', {'name': rule['destination_link']})
-            if not dest_obj and rule['return_type'] == 'REGULAR':
-                module.fail_json(msg='destination_link %s does not exist' % rule['destination_link'])
-
             tf_rule = dict(
                 dest_type=rule['dest_type'],
-                destination_link=dest_obj[0]['_ref'] if dest_obj else None,
                 return_type=rule['return_type']
             )
+
+            if rule['destination'] and rule['return_type'] == 'REGULAR':
+                tf_rule['destination'] = destination_transform(
+                    rule['destination'], rule['dest_type'], module)
+            elif not rule['destination'] and rule['return_type'] == 'REGULAR':
+                module.fail_json(msg='destination is required when return_type is REGULAR')
 
             if rule['sources']:
                 tf_rule['sources'] = sources_transform(rule['sources'], module)
@@ -215,9 +245,14 @@ def main():
         source_value=dict(required=True, type='str')
     )
 
+    destination_spec = dict(
+        destination_link=dict(required=True, type='str'),
+        priority=dict(required=True, type='int')
+    )
+
     rule_spec = dict(
         dest_type=dict(required=True, choices=['POOL', 'SERVER']),
-        destination_link=dict(type='str'),
+        destination=dict(type='list', elements='dict', options=destination_spec),
         return_type=dict(default='REGULAR', choices=['NOERR', 'NXDOMAIN', 'REGULAR']),
         sources=dict(type='list', elements='dict', options=source_spec)
     )

--- a/tests/integration/targets/nios_dtc_topology/tasks/nios_dtc_topology_idempotence.yaml
+++ b/tests/integration/targets/nios_dtc_topology/tasks/nios_dtc_topology_idempotence.yaml
@@ -55,7 +55,9 @@
     name: a_topology
     rules:
       - dest_type: POOL
-        destination_link: web_pool
+        destination:
+          - destination_link: web_pool
+            priority: 1
         return_type: REGULAR
     state: present
     provider: "{{ nios_provider }}"

--- a/tests/unit/plugins/modules/test_nios_dtc_topology.py
+++ b/tests/unit/plugins/modules/test_nios_dtc_topology.py
@@ -65,7 +65,10 @@ class TestNiosDtcTopologyModule(TestNiosModule):
             'name': 'a_topology',
             'rules': [{
                 'dest_type': 'POOL',
-                'destination_link': 'web_pool',
+                'destination': [
+                    {'destination_link': 'web_pool1', 'priority': 1},
+                    {'destination_link': 'web_pool2', 'priority': 2}
+                ],
                 'return_type': 'REGULAR'
             }],
             'comment': None,
@@ -91,7 +94,10 @@ class TestNiosDtcTopologyModule(TestNiosModule):
                 'name': 'a_topology',
                 'rules': [{
                     'dest_type': 'POOL',
-                    'destination_link': 'web_pool',
+                    'destination': [
+                        {'destination_link': 'web_pool1', 'priority': 1},
+                        {'destination_link': 'web_pool2', 'priority': 2}
+                    ],
                     'return_type': 'REGULAR'
                 }]
             }


### PR DESCRIPTION
Fixes #342 

Tests ran against 9.1.0 with WAPI 2.14:
- Creation
- Deletion
- Update
- Idempotency of all of the above