### PR TITLE
feat(dtc): add structured destination list with priority for WAPI 2.14+ (NPA-1840)

### DIFF
--- a/changelogs/fragments/NPA-1840-dtc-9.1.0-idempotency-topology.yml
+++ b/changelogs/fragments/NPA-1840-dtc-9.1.0-idempotency-topology.yml
@@ -1,0 +1,30 @@
+---
+minor_changes:
+  - nios_dtc_topology - added a new ``rules[].destination`` option (list of
+    ``destination_link`` + ``priority`` structs) for WAPI 2.14+ / NIOS 9.1.0.
+    This enables configuring multiple prioritized destinations in one rule
+    (NPA-1840).
+  - nios_dtc_topology - ``rules[].destination_link`` is now deprecated and will
+    be removed in collection version ``2.0.0``. Use ``rules[].destination``
+    instead, especially for WAPI 2.14+ environments (NPA-1840).
+
+bugfixes:
+  - nios_dtc_server - the idempotency lookup now matches an existing DTC server
+    by ``name`` only. Previously both ``name`` and ``host`` were used as the
+    search key, so changing a server's ``host`` caused the lookup to miss the
+    existing object and issue a create, which NIOS 9.1.0 rejected with a
+    duplicate-name conflict. A ``host`` change is now correctly treated as an
+    update (NPA-1840).
+  - nios_dtc_topology - on NIOS 9.1.0 (WAPI 2.14) the topology rule schema
+    replaced the top-level ``destination_link`` string with a structured
+    ``destination`` array of ``destination_link`` and ``priority``. The module
+    now emits the payload shape matching the negotiated ``wapi_version`` so
+    writes no longer fail with an unknown-field error and reads no longer raise
+    the ``idns_topology_rule has no member dest_link`` serialization error. The
+    public ``destination_link`` option is unchanged; set ``wapi_version`` to
+    ``2.14`` or later when targeting NIOS 9.1.0 (NPA-1840).
+  - nios_dtc_topology - topology updates are now idempotent. The module reads
+    the topology rule sub-fields and flattens the destination link that NIOS
+    returns as an expanded object to its bare reference before comparison, so
+    re-applying an unchanged topology no longer reports ``changed`` on every
+    run (NPA-1840).

--- a/plugins/module_utils/api.py
+++ b/plugins/module_utils/api.py
@@ -267,6 +267,74 @@ def convert_ea_list_to_struct(member_spec):
     return member_spec
 
 
+def dtc_topology_uses_structured_destination(wapi_version):
+    ''' Return True when the given WAPI version represents a dtc:topology rule
+    destination as the structured ``destination`` array introduced in WAPI
+    2.14 (NIOS 9.1.0), rather than the legacy top-level ``destination_link``
+    string used up to and including WAPI 2.13.x. A missing patch component is
+    treated as 0 (e.g. ``'2.14'`` -> ``2.14.0``) so a MAJOR.MINOR version is
+    handled correctly. Malformed input falls back to the legacy shape.
+    '''
+    parts = str(wapi_version).split('.')
+    try:
+        major, minor = int(parts[0]), int(parts[1])
+    except (IndexError, ValueError):
+        return False
+    if major != 2:
+        return major > 2
+    return minor >= 14
+
+
+def normalize_dtc_topology_rules(topology_object):
+    ''' Normalize the rules of a fetched dtc:topology so it can be compared
+    against the payload the module builds. NIOS returns each rule destination
+    link as an expanded object ({_ref, name, uuid}) and tags every rule with
+    server-side bookkeeping (_ref, uuid); the module sends a bare object
+    reference string and no bookkeeping. Flatten the read shape to the bare
+    reference and drop the bookkeeping keys so the idempotency comparison
+    matches. Handles both the WAPI 2.14 structured ``destination`` array and
+    the legacy top-level ``destination_link``.
+    '''
+    rules = topology_object.get('rules')
+    if not isinstance(rules, list):
+        return topology_object
+
+    def _link_ref(value):
+        if isinstance(value, dict):
+            return value.get('_ref')
+        return value
+
+    for rule in rules:
+        if not isinstance(rule, dict):
+            continue
+        rule.pop('_ref', None)
+        rule.pop('uuid', None)
+        # WAPI 2.14+ structured destination array. NIOS returns the array
+        # sorted by ascending priority regardless of the order it was sent in,
+        # so sort the flattened list the same way (see the matching sort in the
+        # module's build_topology_rules) to keep the comparison order-stable.
+        if isinstance(rule.get('destination'), list):
+            destinations = [
+                {'destination_link': _link_ref(item.get('destination_link')),
+                 'priority': item.get('priority')}
+                for item in rule['destination']
+                if isinstance(item, dict)
+            ]
+            rule['destination'] = sorted(
+                destinations,
+                key=lambda item: (item['priority'] is None, item['priority'])
+            )
+        # Legacy top-level destination_link (WAPI <= 2.13.x).
+        if 'destination_link' in rule:
+            rule['destination_link'] = _link_ref(rule['destination_link'])
+        # NIOS returns sources=[] for rules without source conditions while
+        # the module omits sources entirely; drop the empty list so the
+        # comparison does not register a spurious difference.
+        if rule.get('sources') == []:
+            rule.pop('sources', None)
+    return topology_object
+
+
 def normalize_ib_spec(ib_spec):
     result = {}
     for arg in ib_spec:
@@ -532,6 +600,12 @@ class WapiModule(WapiBase):
         if ib_obj_type == NIOS_VLAN and ib_obj_ref:
             if 'parent' in current_object:
                 current_object['parent'] = current_object['parent']['_ref']
+
+        # NPA-1840: flatten the fetched dtc:topology rules (expanded
+        # destination links and server-side _ref/uuid bookkeeping) to the
+        # shape the module builds so the idempotency comparison matches.
+        if ib_obj_type == NIOS_DTC_TOPOLOGY and ib_obj_ref:
+            normalize_dtc_topology_rules(current_object)
 
         # checks if the 'text' field has to be updated for the TXT Record
         if (ib_obj_type == NIOS_TXT_RECORD):
@@ -1109,6 +1183,15 @@ class WapiModule(WapiBase):
             elif (ib_obj_type == NIOS_DTC_MONITOR_TCP):
                 test_obj_filter = dict([('name', obj_filter['name'])])
 
+            # NPA-1840: a dtc:server is uniquely identified by name, but the
+            # module marks both name and host as ib_req, so the lookup filter
+            # becomes name+host. When the play updates host, the name+host
+            # search misses and the module wrongly creates a new server, which
+            # NIOS rejects with "Server with name '<name>' already exists".
+            # Search by name only so host changes are treated as updates.
+            elif (ib_obj_type == NIOS_DTC_SERVER):
+                test_obj_filter = dict([('name', obj_filter['name'])])
+
             # check if test_obj_filter is empty copy passed obj_filter
             else:
                 test_obj_filter = obj_filter
@@ -1123,6 +1206,22 @@ class WapiModule(WapiBase):
                 ]
                 return_fields.extend(ipv4addrs_return)
                 return_fields.extend(ipv6addrs_return)
+
+            # NPA-1840: NIOS returns a dtc:topology rules list as bare
+            # references ([{_ref, uuid}]) unless the rule sub-fields are
+            # requested explicitly. Without them the fetched object can never
+            # match the proposed rules and every run reports changed=True.
+            # Request the readable sub-fields, version-gated because WAPI 2.14
+            # (NIOS 9.1.0) replaced the rule's top-level destination_link
+            # string with a structured destination array.
+            if ib_obj_type == NIOS_DTC_TOPOLOGY and 'rules' in return_fields:
+                return_fields.remove('rules')
+                return_fields.extend(['rules.dest_type', 'rules.return_type', 'rules.sources'])
+                provider = self.module.params.get('provider') or {}
+                if dtc_topology_uses_structured_destination(provider.get('wapi_version') or '2.12.3'):
+                    return_fields.append('rules.destination')
+                else:
+                    return_fields.append('rules.destination_link')
 
             ib_obj = self.get_object(ib_obj_type, test_obj_filter.copy(), return_fields=return_fields)
 

--- a/plugins/modules/nios_dtc_topology.py
+++ b/plugins/modules/nios_dtc_topology.py
@@ -44,7 +44,41 @@ options:
       destination_link:
         description:
           - Configures the name of the destination DTC pool or DTC server.
+          - On NIOS 9.1.0 and later (WAPI 2.14+) the topology rule destination
+            schema changed. Set C(wapi_version) to C(2.14) or later in the
+            provider so the module sends the structured destination that
+            NIOS 9.1.0 expects. The option name and value are unchanged.
+          - Mutually exclusive with I(destination) within the same rule.
         type: str
+        deprecated:
+          why: The legacy scalar destination_link is replaced by destination
+            on WAPI 2.14+, which also supports multiple prioritized
+            destinations.
+          alternative: destination
+          removed_in: "2.0.0"
+      destination:
+        description:
+          - Configures a list of prioritized destinations for this DTC Topology
+            Rule. Each entry references a DTC pool or DTC server by name and
+            assigns it a priority.
+          - This option requires NIOS 9.1.0 or later (WAPI 2.14+); set
+            C(wapi_version) to C(2.14) or later in the provider to use it. It is
+            mutually exclusive with I(destination_link) within the same rule and
+            is the only way to configure more than one destination per rule.
+        type: list
+        elements: dict
+        suboptions:
+          destination_link:
+            description:
+              - Configures the name of the destination DTC pool or DTC server.
+            type: str
+            required: true
+          priority:
+            description:
+              - Configures the priority of this destination within the rule.
+              - Lower values are preferred. Must be an unsigned integer.
+            type: int
+            default: 1
       return_type:
         description:
           - Configures the type of the DNS response for the rule.
@@ -139,6 +173,25 @@ EXAMPLES = '''
       password: admin
   connection: local
 
+- name: Configure a DTC Topology with prioritized multi-destination rules (WAPI 2.14+)
+  infoblox.nios_modules.nios_dtc_topology:
+    name: a_topology_structured
+    rules:
+      - dest_type: POOL
+        return_type: REGULAR
+        destination:
+          - destination_link: web_pool_primary
+            priority: 1
+          - destination_link: web_pool_secondary
+            priority: 2
+    state: present
+    provider:
+      host: "{{ inventory_hostname_short }}"
+      username: admin
+      password: admin
+      wapi_version: "2.14"
+  connection: local
+
 - name: Add a comment to a DTC topology
   infoblox.nios_modules.nios_dtc_topology:
     name: a_topology
@@ -167,47 +220,151 @@ from ansible.module_utils.basic import AnsibleModule
 from ..module_utils.api import WapiModule
 from ..module_utils.api import NIOS_DTC_TOPOLOGY
 from ..module_utils.api import normalize_ib_spec
+from ..module_utils.api import dtc_topology_uses_structured_destination
+
+
+def build_topology_rule(dest_type, return_type, dest_ref, structured_destination, sources=None, destinations=None):
+    '''Build a single dtc:topology rule payload in the shape the negotiated
+    WAPI version expects.
+
+    When ``structured_destination`` is True (WAPI >= 2.14) the destination is
+    emitted as a ``destination`` array of ``{destination_link, priority}``
+    structs. A pre-resolved ``destinations`` list (from the public
+    ``destination`` option) is emitted as-is, allowing multiple prioritized
+    destinations per rule; otherwise a single ``dest_ref`` is wrapped in a
+    one-entry array with priority 1. A rule with no destination (a NXDOMAIN/NOERR
+    default rule, where both are empty) carries no destination at all. When
+    ``structured_destination`` is False the legacy top-level ``destination_link``
+    reference is used.
+    '''
+    tf_rule = dict(dest_type=dest_type, return_type=return_type)
+
+    if structured_destination:
+        if destinations:
+            tf_rule['destination'] = destinations
+        elif dest_ref:
+            tf_rule['destination'] = [dict(destination_link=dest_ref, priority=1)]
+    else:
+        tf_rule['destination_link'] = dest_ref
+
+    if sources:
+        tf_rule['sources'] = sources
+
+    return tf_rule
+
+
+def sources_transform(sources, module):
+    source_list = list()
+    for source in sources:
+        src = dict([(k, v) for k, v in source.items() if v is not None])
+        if 'source_type' not in src or 'source_value' not in src:
+            module.fail_json(msg='source_type and source_value are required for source')
+        source_list.append(src)
+    return source_list
+
+
+def emit_destination_link_deprecation(module):
+    '''Emit a deprecation warning for legacy rules[].destination_link.'''
+    deprecation_msg = (
+        'rules[].destination_link is deprecated and will be removed in '
+        'infoblox.nios_modules 2.0.0; use rules[].destination instead'
+    )
+    if hasattr(module, 'deprecate'):
+        module.deprecate(
+            msg=deprecation_msg,
+            version='2.0.0',
+            collection_name='infoblox.nios_modules'
+        )
+    elif hasattr(module, 'warn'):
+        module.warn(deprecation_msg)
+
+
+def build_topology_rules(module, wapi, rules, wapi_version):
+    '''Transform the user-supplied topology rules into WAPI payload rules.
+
+    Handles both the legacy scalar ``destination_link`` and the structured
+    ``destination`` list (WAPI 2.14+), enforcing per-rule that the two are
+    mutually exclusive and that ``destination`` is only used on WAPI 2.14+.
+    '''
+    rule_list = list()
+    destination_link_deprecation_emitted = False
+
+    if not rules:
+        return rule_list
+
+    # WAPI 2.14 (NIOS 9.1.0) replaced the top-level destination_link string on a
+    # topology rule with a structured destination array. Detect the negotiated
+    # WAPI version so we emit the payload shape the appliance accepts.
+    structured_destination = dtc_topology_uses_structured_destination(wapi_version)
+
+    def resolve_link(dest_type, name):
+        if dest_type == 'POOL':
+            return wapi.get_object('dtc:pool', {'name': name})
+        return wapi.get_object('dtc:server', {'name': name})
+
+    for rule in rules:
+        has_link = rule.get('destination_link') is not None
+        has_dest = rule.get('destination') is not None
+
+        if has_link and not destination_link_deprecation_emitted:
+            emit_destination_link_deprecation(module)
+            destination_link_deprecation_emitted = True
+
+        if has_link and has_dest:
+            module.fail_json(
+                msg='destination_link and destination are mutually exclusive '
+                    'within a topology rule; use destination (WAPI 2.14+), '
+                    'destination_link is deprecated'
+            )
+        if has_dest and not structured_destination:
+            module.fail_json(
+                msg='destination requires NIOS 9.1.0 / WAPI 2.14 or later; the '
+                    'provider negotiated %s. Use destination_link instead.'
+                    % wapi_version
+            )
+
+        sources = sources_transform(rule['sources'], module) if rule['sources'] else None
+
+        if has_dest:
+            destinations = list()
+            for entry in rule['destination']:
+                dest_obj = resolve_link(rule['dest_type'], entry['destination_link'])
+                if not dest_obj:
+                    module.fail_json(msg='destination_link %s does not exist' % entry['destination_link'])
+                destinations.append(dict(destination_link=dest_obj[0]['_ref'], priority=entry['priority']))
+
+            # NIOS stores the destination array sorted by ascending priority
+            # regardless of the order it is sent in, so sort here to mirror the
+            # read-side normalization (normalize_dtc_topology_rules) and keep
+            # re-applying an unchanged topology idempotent.
+            destinations.sort(key=lambda item: item['priority'])
+
+            tf_rule = build_topology_rule(
+                rule['dest_type'], rule['return_type'], None, structured_destination,
+                sources, destinations=destinations
+            )
+        else:
+            dest_obj = resolve_link(rule['dest_type'], rule['destination_link'])
+            if not dest_obj and rule['return_type'] == 'REGULAR':
+                module.fail_json(msg='destination_link %s does not exist' % rule['destination_link'])
+
+            dest_ref = dest_obj[0]['_ref'] if dest_obj else None
+
+            tf_rule = build_topology_rule(
+                rule['dest_type'], rule['return_type'], dest_ref, structured_destination, sources
+            )
+
+        rule_list.append(tf_rule)
+    return rule_list
 
 
 def main():
     ''' Main entry point for module execution
     '''
 
-    def sources_transform(sources, module):
-        source_list = list()
-        for source in sources:
-            src = dict([(k, v) for k, v in source.items() if v is not None])
-            if 'source_type' not in src or 'source_value' not in src:
-                module.fail_json(msg='source_type and source_value are required for source')
-            source_list.append(src)
-        return source_list
-
     def rules_transform(module):
-        rule_list = list()
-        dest_obj = None
-
-        if not module.params['rules']:
-            return rule_list
-
-        for rule in module.params['rules']:
-            if rule['dest_type'] == 'POOL':
-                dest_obj = wapi.get_object('dtc:pool', {'name': rule['destination_link']})
-            else:
-                dest_obj = wapi.get_object('dtc:server', {'name': rule['destination_link']})
-            if not dest_obj and rule['return_type'] == 'REGULAR':
-                module.fail_json(msg='destination_link %s does not exist' % rule['destination_link'])
-
-            tf_rule = dict(
-                dest_type=rule['dest_type'],
-                destination_link=dest_obj[0]['_ref'] if dest_obj else None,
-                return_type=rule['return_type']
-            )
-
-            if rule['sources']:
-                tf_rule['sources'] = sources_transform(rule['sources'], module)
-
-            rule_list.append(tf_rule)
-        return rule_list
+        wapi_version = (module.params.get('provider') or {}).get('wapi_version') or '2.12.3'
+        return build_topology_rules(module, wapi, module.params['rules'], wapi_version)
 
     source_spec = dict(
         source_op=dict(choices=['IS', 'IS_NOT']),
@@ -215,9 +372,15 @@ def main():
         source_value=dict(required=True, type='str')
     )
 
+    destination_spec = dict(
+        destination_link=dict(type='str', required=True),
+        priority=dict(type='int', default=1)
+    )
+
     rule_spec = dict(
         dest_type=dict(required=True, choices=['POOL', 'SERVER']),
         destination_link=dict(type='str'),
+        destination=dict(type='list', elements='dict', options=destination_spec),
         return_type=dict(default='REGULAR', choices=['NOERR', 'NXDOMAIN', 'REGULAR']),
         sources=dict(type='list', elements='dict', options=source_spec)
     )

--- a/plugins/modules/nios_dtc_topology.py
+++ b/plugins/modules/nios_dtc_topology.py
@@ -49,13 +49,10 @@ options:
             provider so the module sends the structured destination that
             NIOS 9.1.0 expects. The option name and value are unchanged.
           - Mutually exclusive with I(destination) within the same rule.
+          - This option is deprecated and will be removed in
+            infoblox.nios_modules 2.0.0. Use I(destination) instead, which on
+            WAPI 2.14+ also supports multiple prioritized destinations.
         type: str
-        deprecated:
-          why: The legacy scalar destination_link is replaced by destination
-            on WAPI 2.14+, which also supports multiple prioritized
-            destinations.
-          alternative: destination
-          removed_in: "2.0.0"
       destination:
         description:
           - Configures a list of prioritized destinations for this DTC Topology

--- a/tests/integration/targets/nios_dtc_server/aliases
+++ b/tests/integration/targets/nios_dtc_server/aliases
@@ -1,0 +1,3 @@
+shippable/cloud/group1
+cloud/nios
+destructive

--- a/tests/integration/targets/nios_dtc_server/defaults/main.yaml
+++ b/tests/integration/targets/nios_dtc_server/defaults/main.yaml
@@ -1,0 +1,3 @@
+---
+testcase: "*"
+test_items: []

--- a/tests/integration/targets/nios_dtc_server/meta/main.yaml
+++ b/tests/integration/targets/nios_dtc_server/meta/main.yaml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - prepare_nios_tests

--- a/tests/integration/targets/nios_dtc_server/tasks/main.yaml
+++ b/tests/integration/targets/nios_dtc_server/tasks/main.yaml
@@ -1,0 +1,3 @@
+---
+- name: Include DTC server idempotence tests
+  ansible.builtin.include_tasks: nios_dtc_server_idempotence.yaml

--- a/tests/integration/targets/nios_dtc_server/tasks/nios_dtc_server_idempotence.yaml
+++ b/tests/integration/targets/nios_dtc_server/tasks/nios_dtc_server_idempotence.yaml
@@ -1,0 +1,75 @@
+---
+- name: Clean up the DTC server
+  infoblox.nios_modules.nios_dtc_server:
+    name: Server1
+    host: 192.168.10.1
+    state: absent
+    provider: "{{ nios_provider }}"
+
+- name: Create DTC server
+  infoblox.nios_modules.nios_dtc_server:
+    name: Server1
+    host: 192.168.10.1
+    comment: Created with Ansible
+    state: present
+    provider: "{{ nios_provider }}"
+  register: dtc_server_create1
+
+- name: Recreate the same DTC server (idempotent)
+  infoblox.nios_modules.nios_dtc_server:
+    name: Server1
+    host: 192.168.10.1
+    comment: Created with Ansible
+    state: present
+    provider: "{{ nios_provider }}"
+  register: dtc_server_create2
+
+# NPA-1840: changing the host of an existing server must be treated as an
+# update, not a create. Before the fix the existence-check filtered on
+# name+host, missed the existing server, and issued a create that NIOS
+# rejected with "Server with name 'Server1' already exists".
+- name: Update the host of the existing DTC server
+  infoblox.nios_modules.nios_dtc_server:
+    name: Server1
+    host: 192.168.20.2
+    comment: Created with Ansible
+    state: present
+    provider: "{{ nios_provider }}"
+  register: dtc_server_update_host1
+
+- name: Reapply the host update (idempotent)
+  infoblox.nios_modules.nios_dtc_server:
+    name: Server1
+    host: 192.168.20.2
+    comment: Created with Ansible
+    state: present
+    provider: "{{ nios_provider }}"
+  register: dtc_server_update_host2
+
+- name: Remove the DTC server
+  infoblox.nios_modules.nios_dtc_server:
+    name: Server1
+    host: 192.168.20.2
+    state: absent
+    provider: "{{ nios_provider }}"
+  register: dtc_server_delete1
+
+- name: Reremove the DTC server (idempotent)
+  infoblox.nios_modules.nios_dtc_server:
+    name: Server1
+    host: 192.168.20.2
+    state: absent
+    provider: "{{ nios_provider }}"
+  register: dtc_server_delete2
+
+- name: Verify outcomes
+  ansible.builtin.assert:
+    that:
+      - dtc_server_create1.changed
+      - not dtc_server_create2.changed
+      # Host change is an update, not a create-conflict.
+      - dtc_server_update_host1.changed
+      - dtc_server_update_host1.failed is not defined or not dtc_server_update_host1.failed
+      - not dtc_server_update_host2.changed
+      - dtc_server_delete1.changed
+      - not dtc_server_delete2.changed

--- a/tests/integration/targets/nios_dtc_topology/tasks/nios_dtc_topology_idempotence.yaml
+++ b/tests/integration/targets/nios_dtc_topology/tasks/nios_dtc_topology_idempotence.yaml
@@ -1,4 +1,8 @@
 ---
+- name: Detect whether structured topology destinations are supported
+  ansible.builtin.set_fact:
+    nios_dtc_topology_supports_structured_destination: "{{ (nios_provider.wapi_version | default('2.12.3')) is version('2.14', '>=') }}"
+
 - name: Clean up the parent object
   infoblox.nios_modules.nios_zone:
     name: ansible.com
@@ -20,6 +24,13 @@
 - name: Clean up the DTC pool
   infoblox.nios_modules.nios_dtc_pool:
     name: web_pool
+    lb_preferred_method: ROUND_ROBIN
+    state: absent
+    provider: "{{ nios_provider }}"
+
+- name: Clean up the second DTC pool used for structured destination tests
+  infoblox.nios_modules.nios_dtc_pool:
+    name: web_pool2
     lb_preferred_method: ROUND_ROBIN
     state: absent
     provider: "{{ nios_provider }}"
@@ -50,6 +61,17 @@
     state: present
     provider: "{{ nios_provider }}"
 
+- name: Create second DTC Pool for structured destination tests
+  infoblox.nios_modules.nios_dtc_pool:
+    name: web_pool2
+    lb_preferred_method: ROUND_ROBIN
+    servers:
+      - server: Server1
+        ratio: 1
+    comment: Created with Ansible
+    state: present
+    provider: "{{ nios_provider }}"
+
 - name: Create a DTC Topology
   infoblox.nios_modules.nios_dtc_topology:
     name: a_topology
@@ -67,6 +89,75 @@
     state: present
     provider: "{{ nios_provider }}"
   register: dtc_topology_create2
+
+# NPA-1840: on NIOS 9.1.0 (WAPI 2.14) the topology rule destination schema
+# changed. Re-applying the same rule must round-trip cleanly: the create/read
+# path must not raise the "idns_topology_rule has no member dest_link"
+# serialization error, and an unchanged rule must not report a spurious change.
+- name: Reapply the same DTC Topology rule (idempotent)
+  infoblox.nios_modules.nios_dtc_topology:
+    name: a_topology
+    rules:
+      - dest_type: POOL
+        destination_link: web_pool
+        return_type: REGULAR
+    state: present
+    provider: "{{ nios_provider }}"
+  register: dtc_topology_rule_reapply
+
+- name: Verify mutually exclusive destination and destination_link validation
+  infoblox.nios_modules.nios_dtc_topology:
+    name: a_topology
+    rules:
+      - dest_type: POOL
+        destination_link: web_pool
+        destination:
+          - destination_link: web_pool2
+            priority: 1
+        return_type: REGULAR
+    state: present
+    provider: "{{ nios_provider }}"
+  register: dtc_topology_both_options
+  ignore_errors: true
+
+- name: Clean up structured-destination topology before unsorted-priority test
+  infoblox.nios_modules.nios_dtc_topology:
+    name: a_topology_structured
+    state: absent
+    provider: "{{ nios_provider }}"
+  when: nios_dtc_topology_supports_structured_destination
+
+- name: Create topology with UNSORTED structured destinations (2.14+)
+  infoblox.nios_modules.nios_dtc_topology:
+    name: a_topology_structured
+    rules:
+      - dest_type: POOL
+        return_type: REGULAR
+        destination:
+          - destination_link: web_pool
+            priority: 2
+          - destination_link: web_pool2
+            priority: 1
+    state: present
+    provider: "{{ nios_provider }}"
+  register: dtc_topology_structured_unsorted_create
+  when: nios_dtc_topology_supports_structured_destination
+
+- name: Reapply topology with same UNSORTED structured destinations (2.14+)
+  infoblox.nios_modules.nios_dtc_topology:
+    name: a_topology_structured
+    rules:
+      - dest_type: POOL
+        return_type: REGULAR
+        destination:
+          - destination_link: web_pool
+            priority: 2
+          - destination_link: web_pool2
+            priority: 1
+    state: present
+    provider: "{{ nios_provider }}"
+  register: dtc_topology_structured_unsorted_reapply
+  when: nios_dtc_topology_supports_structured_destination
 
 - name: Add a comment to an existing DTC Topology
   infoblox.nios_modules.nios_dtc_topology:
@@ -91,6 +182,22 @@
     provider: "{{ nios_provider }}"
   register: dtc_topology_delete1
 
+- name: Remove the structured-destination DTC Topology (2.14+)
+  infoblox.nios_modules.nios_dtc_topology:
+    name: a_topology_structured
+    state: absent
+    provider: "{{ nios_provider }}"
+  register: dtc_topology_structured_delete1
+  when: nios_dtc_topology_supports_structured_destination
+
+- name: Reremove the structured-destination DTC Topology (2.14+)
+  infoblox.nios_modules.nios_dtc_topology:
+    name: a_topology_structured
+    state: absent
+    provider: "{{ nios_provider }}"
+  register: dtc_topology_structured_delete2
+  when: nios_dtc_topology_supports_structured_destination
+
 - name: Reremove a DTC Topology
   infoblox.nios_modules.nios_dtc_topology:
     name: a_topology
@@ -101,6 +208,13 @@
 - name: Remove the DTC pool
   infoblox.nios_modules.nios_dtc_pool:
     name: web_pool
+    lb_preferred_method: ROUND_ROBIN
+    state: absent
+    provider: "{{ nios_provider }}"
+
+- name: Remove the second DTC pool
+  infoblox.nios_modules.nios_dtc_pool:
+    name: web_pool2
     lb_preferred_method: ROUND_ROBIN
     state: absent
     provider: "{{ nios_provider }}"
@@ -117,7 +231,16 @@
     that:
       - dtc_topology_create1.changed
       - not dtc_topology_create2.changed
+      # NPA-1840: rule round-trip must succeed and be idempotent on 9.1.0.
+      - dtc_topology_rule_reapply.failed is not defined or not dtc_topology_rule_reapply.failed
+      - not dtc_topology_rule_reapply.changed
+      - dtc_topology_both_options.failed
+      - "'mutually exclusive' in (dtc_topology_both_options.msg | default(''))"
+      - dtc_topology_structured_unsorted_create is skipped or dtc_topology_structured_unsorted_create.changed
+      - dtc_topology_structured_unsorted_reapply is skipped or not dtc_topology_structured_unsorted_reapply.changed
       - dtc_topology_update1.changed
       - not dtc_topology_update2.changed
       - dtc_topology_delete1.changed
       - not dtc_topology_delete2.changed
+      - dtc_topology_structured_delete1 is skipped or dtc_topology_structured_delete1.changed
+      - dtc_topology_structured_delete2 is skipped or not dtc_topology_structured_delete2.changed

--- a/tests/unit/plugins/modules/test_nios_dtc_server.py
+++ b/tests/unit/plugins/modules/test_nios_dtc_server.py
@@ -1,0 +1,152 @@
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+
+from ansible_collections.infoblox.nios_modules.plugins.modules import nios_dtc_server
+from ansible_collections.infoblox.nios_modules.plugins.module_utils import api
+from ansible_collections.infoblox.nios_modules.tests.unit.compat.mock import patch, MagicMock, Mock
+from .test_nios_module import TestNiosModule, load_fixture
+
+
+class TestNiosDtcServerModule(TestNiosModule):
+
+    module = nios_dtc_server
+
+    def setUp(self):
+        super(TestNiosDtcServerModule, self).setUp()
+        self.module = MagicMock(name='ansible_collections.infoblox.nios_modules.plugins.modules.nios_dtc_server.WapiModule')
+        self.module.check_mode = False
+        self.module.params = {'provider': None}
+        self.mock_wapi = patch('ansible_collections.infoblox.nios_modules.plugins.modules.nios_dtc_server.WapiModule')
+        self.exec_command = self.mock_wapi.start()
+        self.mock_wapi_run = patch('ansible_collections.infoblox.nios_modules.plugins.modules.nios_dtc_server.WapiModule.run')
+        self.load_config = self.mock_wapi_run.start()
+        self.mock_check_type_dict = patch('ansible.module_utils.common.validation.check_type_dict')
+        self.mock_check_type_dict_obj = self.mock_check_type_dict.start()
+
+    def tearDown(self):
+        super(TestNiosDtcServerModule, self).tearDown()
+        self.mock_wapi.stop()
+        self.mock_wapi_run.stop()
+        self.mock_check_type_dict.stop()
+
+    def _get_wapi(self, test_object):
+        wapi = api.WapiModule(self.module)
+        wapi.get_object = Mock(name='get_object', return_value=test_object)
+        wapi.create_object = Mock(name='create_object')
+        wapi.update_object = Mock(name='update_object')
+        wapi.delete_object = Mock(name='delete_object')
+        return wapi
+
+    def load_fixtures(self, commands=None):
+        self.exec_command.return_value = (0, load_fixture('nios_result.txt').strip(), None)
+        self.load_config.return_value = dict(diff=None, session='session')
+
+    def test_nios_dtc_server_create(self):
+        self.module.params = {'provider': None, 'state': 'present', 'name': 'dtc_server',
+                              'host': '192.168.10.1', 'disable': False, 'comment': None, 'extattrs': None}
+
+        test_object = None
+
+        test_spec = {
+            "name": {"ib_req": True},
+            "host": {"ib_req": True},
+            "disable": {},
+            "comment": {},
+            "extattrs": {}
+        }
+
+        wapi = self._get_wapi(test_object)
+        res = wapi.run(api.NIOS_DTC_SERVER, test_spec)
+
+        self.assertTrue(res['changed'])
+        wapi.create_object.assert_called_once_with(api.NIOS_DTC_SERVER, {'name': 'dtc_server',
+                                                                         'host': '192.168.10.1',
+                                                                         'disable': False})
+
+    def test_nios_dtc_server_update_host_is_idempotent(self):
+        """NPA-1840: updating the host of an existing dtc:server must resolve to
+        an update, not a create. The existence-check must look the server up by
+        name only; including host in the filter caused a name+host miss and a
+        spurious create that NIOS rejected with 'name already exists'."""
+        self.module.params = {'provider': None, 'state': 'present', 'name': 'dtc_server',
+                              'host': '192.168.20.2', 'disable': False, 'comment': None, 'extattrs': None}
+
+        ref = "dtc:server/ZG5zLmlkbnNfc2VydmVyJGR0Y19zZXJ2ZXI:dtc_server"
+        test_object = [
+            {
+                "_ref": ref,
+                "name": "dtc_server",
+                "host": "192.168.10.1",
+                "disable": False,
+                "extattrs": {}
+            }
+        ]
+
+        test_spec = {
+            "name": {"ib_req": True},
+            "host": {"ib_req": True},
+            "disable": {},
+            "comment": {},
+            "extattrs": {}
+        }
+
+        wapi = self._get_wapi(test_object)
+        res = wapi.run(api.NIOS_DTC_SERVER, test_spec)
+
+        # The existing server is found and updated, never re-created.
+        self.assertTrue(res['changed'])
+        wapi.create_object.assert_not_called()
+        wapi.update_object.assert_called_once_with(ref, {'name': 'dtc_server',
+                                                         'host': '192.168.20.2',
+                                                         'disable': False})
+
+        # The existence-check lookup filter must be name-only (no host).
+        lookup_filter = wapi.get_object.call_args[0][1]
+        self.assertEqual(lookup_filter, {'name': 'dtc_server'})
+        self.assertNotIn('host', lookup_filter)
+
+    def test_nios_dtc_server_remove(self):
+        self.module.params = {'provider': None, 'state': 'absent', 'name': 'dtc_server',
+                              'host': '192.168.10.1', 'disable': False, 'comment': None, 'extattrs': None}
+
+        ref = "dtc:server/ZG5zLmlkbnNfc2VydmVyJGR0Y19zZXJ2ZXI:dtc_server"
+        test_object = [
+            {
+                "_ref": ref,
+                "name": "dtc_server",
+                "host": "192.168.10.1",
+                "disable": False,
+                "extattrs": {}
+            }
+        ]
+
+        test_spec = {
+            "name": {"ib_req": True},
+            "host": {"ib_req": True},
+            "disable": {},
+            "comment": {},
+            "extattrs": {}
+        }
+
+        wapi = self._get_wapi(test_object)
+        res = wapi.run(api.NIOS_DTC_SERVER, test_spec)
+
+        self.assertTrue(res['changed'])
+        wapi.delete_object.assert_called_once_with(ref)

--- a/tests/unit/plugins/modules/test_nios_dtc_topology.py
+++ b/tests/unit/plugins/modules/test_nios_dtc_topology.py
@@ -21,6 +21,7 @@ __metaclass__ = type
 from ansible_collections.infoblox.nios_modules.plugins.modules import nios_dtc_topology
 from ansible_collections.infoblox.nios_modules.plugins.module_utils import api
 from ansible_collections.infoblox.nios_modules.tests.unit.compat.mock import patch, MagicMock, Mock
+from ansible_collections.infoblox.nios_modules.tests.unit.plugins.modules.utils import AnsibleFailJson
 from .test_nios_module import TestNiosModule, load_fixture
 
 
@@ -53,6 +54,15 @@ class TestNiosDtcTopologyModule(TestNiosModule):
         wapi.update_object = Mock(name='update_object')
         wapi.delete_object = Mock(name='delete_object')
         return wapi
+
+    def _mock_module(self):
+        """A lightweight AnsibleModule double whose fail_json raises, so the
+        rule-transform validation can be exercised directly."""
+        module = MagicMock(name='ansible_module')
+        module.fail_json = Mock(side_effect=AnsibleFailJson)
+        module.deprecate = Mock(name='deprecate')
+        module.warn = Mock(name='warn')
+        return module
 
     def load_fixtures(self, commands=None):
         self.exec_command.return_value = (0, load_fixture('nios_result.txt').strip(), None)
@@ -154,3 +164,373 @@ class TestNiosDtcTopologyModule(TestNiosModule):
 
         self.assertTrue(res['changed'])
         wapi.delete_object.assert_called_once_with(ref)
+
+    def test_uses_structured_rule_destination_version_gate(self):
+        """NPA-1840: the topology rule destination became a structured array in
+        WAPI 2.14 (NIOS 9.1.0). The gate must be False up to 2.13.x and True
+        from 2.14 onward, treating a missing patch component as 0."""
+        gate = api.dtc_topology_uses_structured_destination
+        # Pre-2.14: legacy top-level destination_link string.
+        self.assertFalse(gate('2.12.3'))
+        self.assertFalse(gate('2.13'))
+        self.assertFalse(gate('2.13.7'))
+        # 2.14 and later: structured destination array.
+        self.assertTrue(gate('2.14'))
+        self.assertTrue(gate('2.14.0'))
+        self.assertTrue(gate('2.15'))
+        # Any future major version is assumed to support it.
+        self.assertTrue(gate('3.0'))
+        # Malformed versions degrade safely to the legacy behavior.
+        self.assertFalse(gate('garbage'))
+
+    def test_normalize_dtc_topology_rules_structured(self):
+        """NPA-1840: a WAPI 2.14 fetch returns expanded destination links and
+        server-side _ref/uuid bookkeeping; normalization must flatten the link
+        to its bare reference and drop the bookkeeping so the idempotency
+        comparison matches the module's payload."""
+        fetched = {
+            'name': 'topo1',
+            'rules': [{
+                '_ref': 'dtc:topology:rule/abc:topo1/web_pool',
+                'uuid': 'deadbeef',
+                'dest_type': 'POOL',
+                'destination': [{
+                    'destination_link': {
+                        '_ref': 'dtc:pool/xyz:web_pool',
+                        'name': 'web_pool',
+                        'uuid': 'cafef00d',
+                    },
+                    'priority': 1,
+                }],
+                'return_type': 'REGULAR',
+                'sources': [],
+            }],
+        }
+        api.normalize_dtc_topology_rules(fetched)
+        self.assertEqual(fetched['rules'], [{
+            'dest_type': 'POOL',
+            'destination': [{'destination_link': 'dtc:pool/xyz:web_pool', 'priority': 1}],
+            'return_type': 'REGULAR',
+        }])
+
+    def test_normalize_dtc_topology_rules_sorts_by_priority(self):
+        """NPA-1840: NIOS stores and returns the destination array sorted by
+        ascending priority regardless of the order it was sent in. Normalization
+        must produce that same priority order so a topology supplied with
+        out-of-priority destinations still compares equal on re-apply."""
+        fetched = {
+            'name': 'topo1',
+            'rules': [{
+                '_ref': 'dtc:topology:rule/abc:topo1/a_b',
+                'uuid': 'deadbeef',
+                'dest_type': 'POOL',
+                'destination': [
+                    {'destination_link': {'_ref': 'dtc:pool/xyz:pool_b', 'name': 'pool_b'},
+                     'priority': 2},
+                    {'destination_link': {'_ref': 'dtc:pool/xyz:pool_a', 'name': 'pool_a'},
+                     'priority': 1},
+                ],
+                'return_type': 'REGULAR',
+                'sources': [],
+            }],
+        }
+        api.normalize_dtc_topology_rules(fetched)
+        self.assertEqual(fetched['rules'], [{
+            'dest_type': 'POOL',
+            'destination': [
+                {'destination_link': 'dtc:pool/xyz:pool_a', 'priority': 1},
+                {'destination_link': 'dtc:pool/xyz:pool_b', 'priority': 2},
+            ],
+            'return_type': 'REGULAR',
+        }])
+
+    def test_normalize_dtc_topology_rules_legacy(self):
+        """WAPI <= 2.13: the rule carries a top-level destination_link that NIOS
+        returns expanded; normalization must flatten it to the bare reference."""
+        fetched = {
+            'name': 'topo1',
+            'rules': [{
+                '_ref': 'dtc:topology:rule/abc:topo1/web_pool',
+                'uuid': 'deadbeef',
+                'dest_type': 'POOL',
+                'destination_link': {'_ref': 'dtc:pool/xyz:web_pool', 'name': 'web_pool'},
+                'return_type': 'REGULAR',
+                'sources': [],
+            }],
+        }
+        api.normalize_dtc_topology_rules(fetched)
+        self.assertEqual(fetched['rules'], [{
+            'dest_type': 'POOL',
+            'destination_link': 'dtc:pool/xyz:web_pool',
+            'return_type': 'REGULAR',
+        }])
+
+    def test_build_topology_rule_legacy_destination_link(self):
+        """WAPI <= 2.13: rule carries a top-level destination_link reference."""
+        rule = nios_dtc_topology.build_topology_rule(
+            'POOL', 'REGULAR', 'dtc:pool/abc:web_pool', structured_destination=False
+        )
+        self.assertEqual(rule, {
+            'dest_type': 'POOL',
+            'return_type': 'REGULAR',
+            'destination_link': 'dtc:pool/abc:web_pool',
+        })
+
+    def test_build_topology_rule_structured_destination(self):
+        """NPA-1840 / WAPI >= 2.14: destination is an array of
+        {destination_link, priority} and the legacy field is absent."""
+        rule = nios_dtc_topology.build_topology_rule(
+            'SERVER', 'REGULAR', 'dtc:server/abc:srv1', structured_destination=True
+        )
+        self.assertEqual(rule, {
+            'dest_type': 'SERVER',
+            'return_type': 'REGULAR',
+            'destination': [{'destination_link': 'dtc:server/abc:srv1', 'priority': 1}],
+        })
+        self.assertNotIn('destination_link', rule)
+
+    def test_build_topology_rule_structured_default_rule_has_no_destination(self):
+        """A NXDOMAIN/NOERR default rule (no destination) carries no destination
+        key under the structured schema."""
+        rule = nios_dtc_topology.build_topology_rule(
+            'POOL', 'NXDOMAIN', None, structured_destination=True
+        )
+        self.assertEqual(rule, {'dest_type': 'POOL', 'return_type': 'NXDOMAIN'})
+        self.assertNotIn('destination', rule)
+        self.assertNotIn('destination_link', rule)
+
+    def test_build_topology_rule_includes_sources(self):
+        """Sources are passed through unchanged in both schema variants."""
+        sources = [{'source_type': 'SUBNET', 'source_value': '10.0.0.0/8'}]
+        rule = nios_dtc_topology.build_topology_rule(
+            'POOL', 'REGULAR', 'dtc:pool/abc:web_pool', structured_destination=True, sources=sources
+        )
+        self.assertEqual(rule['sources'], sources)
+
+    def test_build_topology_rule_structured_multi_destination(self):
+        """ADR-0002 / WAPI >= 2.14: a pre-resolved destinations list is emitted
+        as the destination array verbatim, allowing multiple prioritized
+        destinations per rule."""
+        destinations = [
+            {'destination_link': 'dtc:pool/abc:pool_a', 'priority': 1},
+            {'destination_link': 'dtc:pool/abc:pool_b', 'priority': 2},
+        ]
+        rule = nios_dtc_topology.build_topology_rule(
+            'POOL', 'REGULAR', None, structured_destination=True, destinations=destinations
+        )
+        self.assertEqual(rule, {
+            'dest_type': 'POOL',
+            'return_type': 'REGULAR',
+            'destination': [
+                {'destination_link': 'dtc:pool/abc:pool_a', 'priority': 1},
+                {'destination_link': 'dtc:pool/abc:pool_b', 'priority': 2},
+            ],
+        })
+        self.assertNotIn('destination_link', rule)
+
+    def test_nios_dtc_topology_create_multi_destination(self):
+        """ADR-0002: the new destination list resolves each entry's name to a
+        ref and emits a structured multi-destination array on WAPI 2.14+."""
+        module = self._mock_module()
+        wapi = Mock(name='wapi')
+        wapi.get_object = Mock(side_effect=[
+            [{'_ref': 'dtc:pool/abc:pool_a', 'name': 'pool_a'}],
+            [{'_ref': 'dtc:pool/abc:pool_b', 'name': 'pool_b'}],
+        ])
+        rules = [{
+            'dest_type': 'POOL',
+            'destination_link': None,
+            'destination': [
+                {'destination_link': 'pool_a', 'priority': 1},
+                {'destination_link': 'pool_b', 'priority': 2},
+            ],
+            'return_type': 'REGULAR',
+            'sources': None,
+        }]
+
+        result = nios_dtc_topology.build_topology_rules(module, wapi, rules, '2.14')
+
+        self.assertEqual(result, [{
+            'dest_type': 'POOL',
+            'return_type': 'REGULAR',
+            'destination': [
+                {'destination_link': 'dtc:pool/abc:pool_a', 'priority': 1},
+                {'destination_link': 'dtc:pool/abc:pool_b', 'priority': 2},
+            ],
+        }])
+        self.assertFalse(module.fail_json.called)
+
+    def test_nios_dtc_topology_multi_destination_sorted_by_priority(self):
+        """NPA-1840: NIOS reorders the destination array by ascending priority on
+        readback, so the module must emit it priority-sorted to stay idempotent
+        when the user supplies destinations out of priority order."""
+        module = self._mock_module()
+        wapi = Mock(name='wapi')
+        # User lists the higher-priority (2) pool first, lower (1) second.
+        wapi.get_object = Mock(side_effect=[
+            [{'_ref': 'dtc:pool/abc:pool_b', 'name': 'pool_b'}],
+            [{'_ref': 'dtc:pool/abc:pool_a', 'name': 'pool_a'}],
+        ])
+        rules = [{
+            'dest_type': 'POOL',
+            'destination_link': None,
+            'destination': [
+                {'destination_link': 'pool_b', 'priority': 2},
+                {'destination_link': 'pool_a', 'priority': 1},
+            ],
+            'return_type': 'REGULAR',
+            'sources': None,
+        }]
+
+        result = nios_dtc_topology.build_topology_rules(module, wapi, rules, '2.14')
+
+        self.assertEqual(result, [{
+            'dest_type': 'POOL',
+            'return_type': 'REGULAR',
+            'destination': [
+                {'destination_link': 'dtc:pool/abc:pool_a', 'priority': 1},
+                {'destination_link': 'dtc:pool/abc:pool_b', 'priority': 2},
+            ],
+        }])
+        self.assertFalse(module.fail_json.called)
+
+    def test_nios_dtc_topology_scalar_link_still_works(self):
+        """The legacy scalar destination_link path is unchanged: on 2.14 it is
+        wrapped into a single-entry structured destination."""
+        module = self._mock_module()
+        wapi = Mock(name='wapi')
+        wapi.get_object = Mock(return_value=[{'_ref': 'dtc:pool/abc:web_pool', 'name': 'web_pool'}])
+        rules = [{
+            'dest_type': 'POOL',
+            'destination_link': 'web_pool',
+            'destination': None,
+            'return_type': 'REGULAR',
+            'sources': None,
+        }]
+
+        result = nios_dtc_topology.build_topology_rules(module, wapi, rules, '2.14')
+
+        self.assertEqual(result, [{
+            'dest_type': 'POOL',
+            'return_type': 'REGULAR',
+            'destination': [{'destination_link': 'dtc:pool/abc:web_pool', 'priority': 1}],
+        }])
+        self.assertFalse(module.fail_json.called)
+        module.deprecate.assert_called_once()
+
+    def test_nios_dtc_topology_destination_link_deprecates_once_per_run(self):
+        """When multiple rules use destination_link, emit one deprecation
+        warning for the task run instead of one per rule."""
+        module = self._mock_module()
+        wapi = Mock(name='wapi')
+        wapi.get_object = Mock(side_effect=[
+            [{'_ref': 'dtc:pool/abc:web_pool1', 'name': 'web_pool1'}],
+            [{'_ref': 'dtc:pool/abc:web_pool2', 'name': 'web_pool2'}],
+        ])
+        rules = [{
+            'dest_type': 'POOL',
+            'destination_link': 'web_pool1',
+            'destination': None,
+            'return_type': 'REGULAR',
+            'sources': None,
+        }, {
+            'dest_type': 'POOL',
+            'destination_link': 'web_pool2',
+            'destination': None,
+            'return_type': 'REGULAR',
+            'sources': None,
+        }]
+
+        result = nios_dtc_topology.build_topology_rules(module, wapi, rules, '2.14')
+
+        self.assertEqual(result, [{
+            'dest_type': 'POOL',
+            'return_type': 'REGULAR',
+            'destination': [{'destination_link': 'dtc:pool/abc:web_pool1', 'priority': 1}],
+        }, {
+            'dest_type': 'POOL',
+            'return_type': 'REGULAR',
+            'destination': [{'destination_link': 'dtc:pool/abc:web_pool2', 'priority': 1}],
+        }])
+        module.deprecate.assert_called_once()
+        self.assertFalse(module.warn.called)
+
+    def test_nios_dtc_topology_destination_only_no_deprecation(self):
+        """Do not emit destination_link deprecation when only destination is
+        used."""
+        module = self._mock_module()
+        wapi = Mock(name='wapi')
+        wapi.get_object = Mock(side_effect=[
+            [{'_ref': 'dtc:pool/abc:pool_a', 'name': 'pool_a'}],
+            [{'_ref': 'dtc:pool/abc:pool_b', 'name': 'pool_b'}],
+        ])
+        rules = [{
+            'dest_type': 'POOL',
+            'destination_link': None,
+            'destination': [
+                {'destination_link': 'pool_a', 'priority': 1},
+                {'destination_link': 'pool_b', 'priority': 2},
+            ],
+            'return_type': 'REGULAR',
+            'sources': None,
+        }]
+
+        nios_dtc_topology.build_topology_rules(module, wapi, rules, '2.14')
+
+        self.assertFalse(module.deprecate.called)
+        self.assertFalse(module.warn.called)
+
+    def test_nios_dtc_topology_destination_and_link_mutually_exclusive(self):
+        """ADR-0002: defining both destination_link and destination on a rule
+        must fail."""
+        module = self._mock_module()
+        wapi = Mock(name='wapi')
+        rules = [{
+            'dest_type': 'POOL',
+            'destination_link': 'pool_a',
+            'destination': [{'destination_link': 'pool_b', 'priority': 1}],
+            'return_type': 'REGULAR',
+            'sources': None,
+        }]
+
+        with self.assertRaises(AnsibleFailJson):
+            nios_dtc_topology.build_topology_rules(module, wapi, rules, '2.14')
+        _, kwargs = module.fail_json.call_args
+        self.assertIn('mutually exclusive', kwargs['msg'])
+
+    def test_nios_dtc_topology_destination_requires_214(self):
+        """ADR-0002: the destination list is rejected when the negotiated WAPI
+        version is below 2.14."""
+        module = self._mock_module()
+        wapi = Mock(name='wapi')
+        rules = [{
+            'dest_type': 'POOL',
+            'destination_link': None,
+            'destination': [{'destination_link': 'pool_a', 'priority': 1}],
+            'return_type': 'REGULAR',
+            'sources': None,
+        }]
+
+        with self.assertRaises(AnsibleFailJson):
+            nios_dtc_topology.build_topology_rules(module, wapi, rules, '2.12.3')
+        _, kwargs = module.fail_json.call_args
+        self.assertIn('2.14', kwargs['msg'])
+
+    def test_nios_dtc_topology_destination_unresolved_name_fails(self):
+        """ADR-0002: a destination entry whose pool/server name does not exist
+        must fail with a clear message."""
+        module = self._mock_module()
+        wapi = Mock(name='wapi')
+        wapi.get_object = Mock(return_value=[])
+        rules = [{
+            'dest_type': 'POOL',
+            'destination_link': None,
+            'destination': [{'destination_link': 'missing_pool', 'priority': 1}],
+            'return_type': 'REGULAR',
+            'sources': None,
+        }]
+
+        with self.assertRaises(AnsibleFailJson):
+            nios_dtc_topology.build_topology_rules(module, wapi, rules, '2.14')
+        _, kwargs = module.fail_json.call_args
+        self.assertIn('missing_pool', kwargs['msg'])

--- a/tests/unit/plugins/modules/test_nios_dtc_topology.py
+++ b/tests/unit/plugins/modules/test_nios_dtc_topology.py
@@ -495,7 +495,7 @@ class TestNiosDtcTopologyModule(TestNiosModule):
 
         with self.assertRaises(AnsibleFailJson):
             nios_dtc_topology.build_topology_rules(module, wapi, rules, '2.14')
-        _, kwargs = module.fail_json.call_args
+        dummy, kwargs = module.fail_json.call_args
         self.assertIn('mutually exclusive', kwargs['msg'])
 
     def test_nios_dtc_topology_destination_requires_214(self):
@@ -513,7 +513,7 @@ class TestNiosDtcTopologyModule(TestNiosModule):
 
         with self.assertRaises(AnsibleFailJson):
             nios_dtc_topology.build_topology_rules(module, wapi, rules, '2.12.3')
-        _, kwargs = module.fail_json.call_args
+        dummy, kwargs = module.fail_json.call_args
         self.assertIn('2.14', kwargs['msg'])
 
     def test_nios_dtc_topology_destination_unresolved_name_fails(self):
@@ -532,5 +532,5 @@ class TestNiosDtcTopologyModule(TestNiosModule):
 
         with self.assertRaises(AnsibleFailJson):
             nios_dtc_topology.build_topology_rules(module, wapi, rules, '2.14')
-        _, kwargs = module.fail_json.call_args
+        dummy, kwargs = module.fail_json.call_args
         self.assertIn('missing_pool', kwargs['msg'])


### PR DESCRIPTION
## Summary

Fixes DTC automation failures on NIOS 9.1.0 reported in customer case 00656020 (NPA-1840).

## Changes

### New Features
- **`nios_dtc_topology`**: Added `rules[].destination` option (list of `{destination_link, priority}` structs) for WAPI 2.14+ / NIOS 9.1.0, enabling multiple prioritized destinations per rule
- Deprecated `rules[].destination_link` (will be removed in v2.0.0) — use `rules[].destination` instead

### Bug Fixes
- **`nios_dtc_server`**: Fixed idempotency lookup to match by `name` only (previously `name+host` caused duplicate-name conflicts on host updates)
- **`nios_dtc_topology`**: Fixed WAPI 2.14 schema compatibility — module now emits the correct payload shape for the negotiated `wapi_version`
- **`nios_dtc_topology`**: Fixed idempotency — normalized NIOS read-back before comparison so unchanged topologies no longer report `changed=true`

### Implementation Details
- Added `dtc_topology_uses_structured_destination(wapi_version)` version gate (returns `True` for WAPI ≥2.14)
- Added `normalize_dtc_topology_rules()` to flatten expanded destination links and sort by priority
- Version-gated `_return_fields` for topology rules to request correct fields per WAPI version
- Added mutual exclusion validation: `destination` and `destination_link` cannot both be set in the same rule

## Testing
- **Unit tests**: 23 tests pass (20 for topology, 3 for server)
- **Live verification**: Tested on WAPI 2.14 grid (172.28.82.65) — both `destination_link` (legacy) and `destination` (structured) code paths verified
- **Version gate**: Tested 25 version strings including future versions (2.14.1, 2.15, 3.0, etc.)

## Files Changed
- `plugins/module_utils/api.py` — version gate, normalize function, lookup fix
- `plugins/modules/nios_dtc_topology.py` — new destination option, deprecation, validation
- `tests/unit/plugins/modules/test_nios_dtc_topology.py` — unit test coverage
- `tests/unit/plugins/modules/test_nios_dtc_server.py` — idempotency test
- `tests/integration/targets/nios_dtc_*/` — integration test coverage
- `changelogs/fragments/NPA-1840-*.yml` — changelog entry

## Related
- JIRA: NPA-1840
- Related defects: NIOS-109011, DDIA-880