### PR TITLE
Fix WAPI 2.14+ post-fetch object retrieval (NPA-1964, #305)

### DIFF
--- a/changelogs/fragments/1964-wapi-2.14-post-fetch-dict.yml
+++ b/changelogs/fragments/1964-wapi-2.14-post-fetch-dict.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - "Fix post-fetch object retrieval on WAPI 2.14+ where create/update returns {_ref, uuid} dict instead of bare _ref string; normalize dict to extract _ref before GET (NPA-1964, related to #305)"

--- a/playbooks/nios_dtc_server_wapi_2_14_example.yml
+++ b/playbooks/nios_dtc_server_wapi_2_14_example.yml
@@ -1,0 +1,71 @@
+---
+# Example: DTC Server Management with WAPI 2.14+
+#
+# This playbook demonstrates DTC server creation, update, and deletion.
+# On WAPI 2.14+, the API returns {_ref, uuid} dict on create/update,
+# which the module now correctly normalizes for post-fetch retrieval.
+#
+# Requirements:
+#   - Infoblox WAPI 2.14+ (NIOS 9.1.0 or later)
+#   - infoblox-client == 0.6.2
+#   - ansible-core >= 2.16
+#
+# Usage:
+#   ansible-playbook nios_dtc_server_wapi_2_14_example.yml -e nios_host=<grid-ip> -e nios_username=admin -e nios_password=<password>
+
+- name: DTC Server Management Example
+  hosts: localhost
+  connection: local
+  gather_facts: false
+
+  vars:
+    # Provide credentials via -e option or set them here
+    nios_provider:
+      host: "{{ nios_host | default('192.168.1.10') }}"
+      username: "{{ nios_username | default('admin') }}"
+      password: "{{ nios_password | default('infoblox') }}"
+      wapi_version: "2.14"
+      ssl_verify: false
+
+  tasks:
+    - name: Create DTC Server
+      infoblox.nios_modules.nios_dtc_server:
+        name: "web-server-01.example.com"
+        host: "10.0.0.100"
+        comment: "Web server for DTC load balancing"
+        state: present
+        provider: "{{ nios_provider }}"
+      register: dtc_server_create
+
+    - name: Display created server
+      ansible.builtin.debug:
+        msg:
+          - "Server Reference: {{ dtc_server_create.object._ref }}"
+          - "Server Name: {{ dtc_server_create.object.name }}"
+          - "Server Host: {{ dtc_server_create.object.host }}"
+
+    - name: Update DTC Server
+      infoblox.nios_modules.nios_dtc_server:
+        name: "web-server-01.example.com"
+        host: "10.0.0.100"
+        comment: "Updated: Web server for DTC load balancing (v2)"
+        state: present
+        provider: "{{ nios_provider }}"
+      register: dtc_server_update
+
+    - name: Display updated server
+      ansible.builtin.debug:
+        msg: "Updated Comment: {{ dtc_server_update.object.comment }}"
+
+    - name: Delete DTC Server
+      infoblox.nios_modules.nios_dtc_server:
+        name: "web-server-01.example.com"
+        host: "10.0.0.100"
+        state: absent
+        provider: "{{ nios_provider }}"
+      register: dtc_server_delete
+
+    - name: Verify deletion
+      ansible.builtin.debug:
+        msg: "DTC server deleted successfully"
+      when: dtc_server_delete.changed

--- a/plugins/module_utils/api.py
+++ b/plugins/module_utils/api.py
@@ -723,6 +723,9 @@ class WapiModule(WapiBase):
                 and not self.module.check_mode
                 and ib_obj_type not in NIOS_RETURN_OBJECT_EXCLUDE):
             target_ref = res if res else ref
+            # Normalize WAPI 2.14+ dict response {_ref, uuid} to bare _ref string
+            if isinstance(target_ref, dict) and '_ref' in target_ref:
+                target_ref = target_ref['_ref']
             if target_ref:
                 return_fields = sorted({
                     k for k in ib_spec.keys()

--- a/tests/unit/plugins/module_utils/test_api.py
+++ b/tests/unit/plugins/module_utils/test_api.py
@@ -1044,3 +1044,45 @@ class TestNiosApi(unittest.TestCase):
 
         self.assertTrue(res['changed'])
         wapi.update_object.assert_not_called()
+
+    def test_post_fetch_normalizes_wapi_2_14_dict_response(self):
+        # WAPI 2.14+ returns {_ref, uuid} dict on create/update; post-fetch
+        # must extract _ref before using it for GET. (issue #305, NPA-1964)
+        self.module.params = {
+            'provider': {}, 'state': 'present',
+            'name': 'server.com', 'host': '2.2.2.2', 'comment': None, 'extattrs': None,
+        }
+        test_spec = {
+            'name': {'ib_req': True},
+            'host': {'ib_req': True},
+            'comment': {},
+            'extattrs': {},
+        }
+        dict_ref = 'dtc:server/ZG5z:server.com'
+        create_response = {
+            '_ref': dict_ref,
+            'uuid': 'c656e2c8abea46af9f4108e378ff2e2a',
+        }
+        fetched_object = {
+            '_ref': dict_ref,
+            'name': 'server.com',
+            'host': '2.2.2.2',
+            'comment': None,
+            'extattrs': {},
+        }
+
+        wapi = api.WapiModule(self.module)
+        wapi.get_object = Mock(return_value=None)
+        wapi.create_object = Mock(return_value=create_response)
+        wapi.update_object = Mock()
+        wapi.delete_object = Mock()
+        wapi.connector.get_object = Mock(return_value=fetched_object)
+
+        res = wapi.run('dtc:server', test_spec)
+
+        self.assertTrue(res['changed'])
+        self.assertIn('object', res)
+        self.assertEqual(res['object']['_ref'], dict_ref)
+        wapi.connector.get_object.assert_called_once()
+        call_kwargs = wapi.connector.get_object.call_args[1]
+        self.assertEqual(call_kwargs['obj_type'], dict_ref)


### PR DESCRIPTION
On WAPI 2.14+, create/update operations return a dict {_ref, uuid} instead of a bare _ref string. The post-fetch GET operation was using this dict directly in the URL construction, resulting in a 400 Bad Request error.

Fix: Normalize the dict response to extract _ref before using it for GET.

- Extract _ref from dict response in post-fetch normalization (version-agnostic)
- Add unit test for dict-to-string normalization in post-fetch
- No impact on 2.13.x and earlier (bare string returns unchanged)
- Resolves warning: "nios post-fetch failed (object was written successfully)"