### PR TITLE
Fix infoblox_client logger noise and handle_exception crash on non-dict response (#123)

### DIFF
--- a/changelogs/fragments/123-infoblox-client-logger-and-bad-credential-error.yml
+++ b/changelogs/fragments/123-infoblox-client-logger-and-bad-credential-error.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - api - fix ``TypeError`` raised in ``handle_exception`` when the WAPI error response is not a dict (for example bad credentials, where the library sets the response to raw bytes); non-dict responses now fall back to a clean error message (https://github.com/infobloxopen/infoblox-ansible/issues/123).
+  - api - attach a NullHandler to the ``infoblox_client`` logger to suppress the "No handlers could be found for logger infoblox_client.connector" warning and library re-authentication log noise when the consuming application has not configured logging (https://github.com/infobloxopen/infoblox-ansible/issues/123).

--- a/plugins/module_utils/api.py
+++ b/plugins/module_utils/api.py
@@ -32,6 +32,7 @@ __metaclass__ = type
 import json
 import os
 import copy
+import logging
 from functools import partial
 from ansible.module_utils.common.text.converters import to_native
 from ansible.module_utils.common.text.converters import to_text
@@ -43,6 +44,10 @@ try:
     from infoblox_client.connector import Connector
     from infoblox_client.exceptions import InfobloxException
     HAS_INFOBLOX_CLIENT = True
+    # Suppress "No handlers could be found for logger 'infoblox_client.connector'" and the
+    # library's re-auth WARNING noise when the consuming app has not configured logging.
+    # https://github.com/infobloxopen/infoblox-ansible/issues/123
+    logging.getLogger('infoblox_client').addHandler(logging.NullHandler())
 except ImportError:
     HAS_INFOBLOX_CLIENT = False
 
@@ -305,7 +310,11 @@ class WapiBase(object):
 class WapiLookup(WapiBase):
     ''' Implements WapiBase for lookup plugins '''
     def handle_exception(self, method_name, exc):
-        response = getattr(exc, 'response', None) or {}
+        response = getattr(exc, 'response', None)
+        # The library sets ``response`` to varying types (dict, bytes, str,
+        # requests.Response); only a dict carries the parsed WAPI error fields.
+        if not isinstance(response, dict):
+            response = {}
         if 'text' in response:
             raise Exception(response['text'])
         else:
@@ -325,7 +334,11 @@ class WapiInventory(WapiBase):
         'handle_exception'" error instead of the real cause (wrong username or
         password, unreachable host, timeout, etc.).
         '''
-        response = getattr(exc, 'response', None) or {}
+        response = getattr(exc, 'response', None)
+        # Only a dict carries parsed WAPI error fields; bad credentials, for
+        # example, set ``response`` to raw bytes which must not reach ``in``.
+        if not isinstance(response, dict):
+            response = {}
         if 'text' in response:
             raise Exception(response['text']) from exc
         raise Exception(exc) from exc
@@ -353,7 +366,13 @@ class WapiModule(WapiBase):
         exception. This method will then gracefully fail the module.
         :args exc: instance of InfobloxException
         '''
-        response = getattr(exc, 'response', None) or {}
+        response = getattr(exc, 'response', None)
+        # The library sets ``response`` to varying types (dict, bytes, str,
+        # requests.Response). Only a dict carries the parsed WAPI error fields;
+        # coerce anything else to {} so the membership/``.get`` checks below are
+        # safe and a non-dict response falls back to ``to_native(exc)``.
+        if not isinstance(response, dict):
+            response = {}
 
         # For state=absent deletes, treat NotFound as idempotent success.
         if method_name == 'delete_object' and self.module.params.get('state') == 'absent':

--- a/tests/unit/plugins/module_utils/test_api.py
+++ b/tests/unit/plugins/module_utils/test_api.py
@@ -646,6 +646,62 @@ class TestNiosApi(unittest.TestCase):
         self.assertEqual(str(cm.exception), 'bad credentials')
 
     # ------------------------------------------------------------------
+    # Issue #123 / NPA-1806 — handle_exception must not crash when the
+    # library sets exc.response to a non-dict (e.g. InfobloxBadWAPICredential
+    # sets response=response.content, which is raw bytes). The old
+    # ``getattr(exc, 'response', None) or {}`` guard only caught falsy values,
+    # so a truthy bytes/str response reached ``'text' in response`` and raised
+    # ``TypeError: a bytes-like object is required, not 'str'``.
+    # ------------------------------------------------------------------
+    def test_wapi_handle_exception_bytes_response_falls_back_to_native(self):
+        '''WapiModule must fall back to to_native(exc) when exc.response is bytes.'''
+        self.module.params = {'provider': {}, 'state': 'present'}
+        self.module.fail_json = Mock(name='fail_json')
+
+        wapi = api.WapiModule(self.module)
+        exc = Exception('bad credentials')
+        exc.response = b'<html>401 Unauthorized</html>'  # bytes, as set on 401
+
+        # Must not raise TypeError — the bug was 'text' in <bytes>.
+        wapi.handle_exception('create_object', exc)
+
+        self.module.fail_json.assert_called_once()
+        call_kwargs = self.module.fail_json.call_args[1]
+        self.assertEqual(call_kwargs.get('msg'), 'bad credentials')
+
+    def test_wapi_lookup_handle_exception_bytes_response_does_not_raise(self):
+        '''WapiLookup must wrap exc (not TypeError) when exc.response is bytes.'''
+        lookup = api.WapiLookup({})
+        exc = Exception('lookup bad credentials')
+        exc.response = b'<html>401 Unauthorized</html>'
+
+        with self.assertRaises(Exception) as cm:
+            lookup.handle_exception('get_object', exc)
+        self.assertNotIsInstance(cm.exception, TypeError)
+        self.assertIn('lookup bad credentials', str(cm.exception))
+
+    def test_wapi_inventory_handle_exception_bytes_response_falls_back(self):
+        '''WapiInventory must wrap exc (not TypeError) when exc.response is bytes.'''
+        inventory = api.WapiInventory({})
+        exc = Exception('inventory bad credentials')
+        exc.response = b'<html>401 Unauthorized</html>'
+
+        with self.assertRaises(Exception) as cm:
+            inventory.handle_exception('get_object', exc)
+        self.assertNotIsInstance(cm.exception, TypeError)
+        self.assertIn('inventory bad credentials', str(cm.exception))
+
+    def test_infoblox_client_logger_has_null_handler(self):
+        '''Importing the api module must attach a NullHandler to the
+        infoblox_client logger so library log records are dropped when the
+        consuming application has not configured logging (issue #123).'''
+        import logging
+        logger = logging.getLogger('infoblox_client')
+        self.assertTrue(
+            any(isinstance(h, logging.NullHandler) for h in logger.handlers)
+        )
+
+    # ------------------------------------------------------------------
     # convert_vlans_to_struct — direct unit tests for the new helper.
     # ------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Fixes #123 (JIRA NPA-1806). The issue reported two symptoms on a failing WAPI call:
`No handlers could be found for logger "infoblox_client.connector"` and a `TypeError`
inside `handle_exception`. Reproduced live against a NIOS grid with bad credentials.

## Root cause

`InfobloxBadWAPICredential` is raised with `response=response.content`, which is **raw bytes**.
In `handle_exception` the guard was:

```python
response = getattr(exc, 'response', None) or {}   # bytes is truthy -> stays bytes
if 'text' in response:                            # 'text' (str) in bytes -> TypeError
```

`or {}` only catches falsy values (None/empty). A truthy non-dict response (bytes / str /
`requests.Response`) slipped through and raised
`TypeError: a bytes-like object is required, not 'str'`. Existing `response = None` tests
passed, which masked this — real bad-credential failures produce a *bytes* response, not None.

Separately, the collection configured no logging at all, so the `infoblox_client.connector`
library logger emitted its re-authentication WARNING lines (and the "No handlers could be
found" message) as noise.

## Changes

- **api** - coerce a non-dict `exc.response` to `{}` in all three `handle_exception` methods
  (`WapiModule`, `WapiLookup`, `WapiInventory`) so bad credentials and other non-dict
  responses fail cleanly with a meaningful message instead of a `TypeError`.
- **api** - attach a `NullHandler` to the `infoblox_client` logger so the library's
  re-auth log noise is suppressed when the consuming application has not configured logging.
- Unit tests: bytes-response coverage for all three classes + a NullHandler assertion.
- Changelog fragment for #123.

## Verification

- `pytest tests/unit/plugins/module_utils/test_api.py` — 54 passed (4 new).
- Behavioral re-run against a NIOS grid with bad credentials:
  - **Before:** `MODULE FAILURE`, a `TypeError: a bytes-like object is required` traceback, and connector WARNING lines on stderr.
  - **After:** clean failure with `Infoblox IPAM is misconfigured: infoblox_username and infoblox_password are incorrect. ... [code 401]`, no traceback, no logger noise.
