### PR TITLE
Support extensible attribute inheritance control (issue #82)

### DIFF
--- a/changelogs/fragments/82-extattrs-inheritance.yml
+++ b/changelogs/fragments/82-extattrs-inheritance.yml
@@ -1,0 +1,11 @@
+---
+minor_changes:
+  - |
+    module_utils/api - extensible attributes now support inheritance control.
+    An ``extattrs`` value may be given as a dict such as
+    ``{value: <v>, inheritance_operation: INHERIT}`` (or ``OVERRIDE``) to revert
+    an object to its inherited value or to explicitly override an inherited one.
+    Previously any dict value was double-nested and rejected by WAPI with
+    "Bad value for extensible attribute". Inherited values read back from NIOS
+    now retain their ``inheritance_source`` metadata instead of being silently
+    flattened (https://github.com/infobloxopen/infoblox-ansible/issues/82).

--- a/playbooks/extattrs_inheritance.yml
+++ b/playbooks/extattrs_inheritance.yml
@@ -1,0 +1,63 @@
+---
+# Demonstrates extensible attribute (EA) inheritance control.
+#
+# In NIOS an EA whose definition is marked "inheritable" propagates from a
+# parent object (e.g. a network container) to its children automatically.
+# A child can override the inherited value, or be reverted back to inheriting
+# it. These examples show how to drive both from Ansible.
+- name: Manage extensible attribute inheritance
+  hosts: localhost
+  connection: local
+  vars:
+    nios_provider:
+      host: 192.0.2.1
+      username: admin
+      password: infoblox
+  tasks:
+    # Parent container carries the inheritable EA value.
+    - name: Create parent network container with an inheritable EA
+      infoblox.nios_modules.nios_network:
+        network: 172.30.0.0/16
+        container: true
+        extattrs:
+          Site: HQ
+        comment: Parent container
+        state: present
+        provider: "{{ nios_provider }}"
+
+    # A plain string value explicitly sets/overrides the EA on the child,
+    # replacing any inherited value (backward-compatible behaviour).
+    - name: Override the inherited EA on a child network
+      infoblox.nios_modules.nios_network:
+        network: 172.30.1.0/24
+        extattrs:
+          Site: Branch
+        comment: Child with overridden EA
+        state: present
+        provider: "{{ nios_provider }}"
+
+    # Revert the child back to inheriting the parent's value by passing a
+    # structured value with inheritance_operation: INHERIT. The 'value' is
+    # required by WAPI but ignored for INHERIT.
+    - name: Revert the child network EA to inheritance
+      infoblox.nios_modules.nios_network:
+        network: 172.30.1.0/24
+        extattrs:
+          Site:
+            value: HQ
+            inheritance_operation: INHERIT
+        comment: Child inheriting parent EA
+        state: present
+        provider: "{{ nios_provider }}"
+
+    # Explicitly override an inherited value using the structured form.
+    - name: Explicitly override an inherited EA on a child network
+      infoblox.nios_modules.nios_network:
+        network: 172.30.2.0/24
+        extattrs:
+          Site:
+            value: Datacenter
+            inheritance_operation: OVERRIDE
+        comment: Child with explicit override
+        state: present
+        provider: "{{ nios_provider }}"

--- a/plugins/module_utils/api.py
+++ b/plugins/module_utils/api.py
@@ -182,8 +182,24 @@ def normalize_extattrs(value):
                 value: <value>
             }
         }
+    A value may also be provided as a dict to control extensible attribute
+    inheritance, e.g.:
+        extattrs: {
+            key: {
+                value: <value>,
+                inheritance_operation: 'INHERIT' | 'OVERRIDE'
+            }
+        }
+    In that case the struct is passed through as-is, except for the read-only
+    'inheritance_source' field which WAPI returns on read but rejects on write.
     '''
-    return dict([(k, {'value': v}) for k, v in value.items()])
+    normalized = {}
+    for k, v in value.items():
+        if isinstance(v, dict):
+            normalized[k] = {ik: iv for ik, iv in v.items() if ik != 'inheritance_source'}
+        else:
+            normalized[k] = {'value': v}
+    return normalized
 
 
 def flatten_extattrs(value):
@@ -198,8 +214,24 @@ def flatten_extattrs(value):
         extattrs: {
             key: value
         }
+    When a value carries inheritance metadata (i.e. it is inherited from a
+    parent object), WAPI returns:
+        extattrs: {
+            key: {
+                value: <value>,
+                inheritance_source: { _ref: <parent> }
+            }
+        }
+    In that case the full struct is preserved so the inherited state stays
+    visible and can be compared for idempotency.
     '''
-    return dict([(k, v['value']) for k, v in value.items()])
+    flattened = {}
+    for k, v in value.items():
+        if isinstance(v, dict) and 'inheritance_source' in v:
+            flattened[k] = v
+        else:
+            flattened[k] = v['value']
+    return flattened
 
 
 def member_normalize(member_spec):
@@ -953,15 +985,35 @@ class WapiModule(WapiBase):
     def compare_extattrs(self, current_extattrs, proposed_extattrs):
         '''Compare current extensible attributes to given extensible
            attribute, if length is not equal returns false , else
-           checks the value of keys in proposed extattrs'''
+           checks the value of keys in proposed extattrs.
+
+           A proposed value may be a plain scalar (legacy behaviour) or a
+           dict controlling inheritance, e.g.
+           {'value': <v>, 'inheritance_operation': 'INHERIT' | 'OVERRIDE'}.
+           The current value may be a scalar (explicitly set) or a dict
+           carrying 'inheritance_source' (inherited from a parent).'''
         if len(current_extattrs) != len(proposed_extattrs):
             return False
-        else:
-            for key, proposed_item in proposed_extattrs.items():
-                current_item = current_extattrs.get(key)
-                if current_item != proposed_item:
+        for key, proposed_item in proposed_extattrs.items():
+            current_item = current_extattrs.get(key)
+            current_inherited = isinstance(current_item, dict) and 'inheritance_source' in current_item
+            current_value = current_item.get('value') if isinstance(current_item, dict) else current_item
+
+            if isinstance(proposed_item, dict):
+                if proposed_item.get('inheritance_operation') == 'INHERIT':
+                    # Up to date only when the value is currently inherited.
+                    if not current_inherited:
+                        return False
+                else:
+                    # Explicit value (optionally OVERRIDE): the effective value
+                    # must match and it must be explicitly set, not inherited.
+                    if current_value != proposed_item.get('value') or current_inherited:
+                        return False
+            else:
+                # Legacy flat value: compare the effective value only.
+                if current_value != proposed_item:
                     return False
-            return True
+        return True
 
     def verify_list_order(self, proposed_data, current_data):
         return len(proposed_data) == len(current_data) and all(a == b for a, b in zip(proposed_data, current_data))
@@ -1074,6 +1126,10 @@ class WapiModule(WapiBase):
                     proposed_extattrs = proposed_object.get(key)
                     if not self.compare_extattrs(current_extattrs, proposed_extattrs):
                         return False
+                    # compare_extattrs is authoritative for extensible attributes
+                    # (it understands inheritance metadata); skip the generic
+                    # recursion below which would misreport inheritance fields.
+                    continue
 
                 if self.compare_objects(current_item, proposed_item, ib_obj_type) is False:
                     return False

--- a/plugins/modules/nios_a_record.py
+++ b/plugins/modules/nios_a_record.py
@@ -57,6 +57,11 @@ options:
       - Allows for the configuration of Extensible Attributes on the
         instance of the object.  This argument accepts a set of key / value
         pairs for configuration.
+      - A value may also be supplied as a dictionary to control inheritance of
+        an inheritable Extensible Attribute. Such a dictionary accepts a
+        C(value) key together with an C(inheritance_operation) key set to
+        C(INHERIT) to revert the object to its inherited value, or C(OVERRIDE)
+        to explicitly override an inherited value.
     type: dict
   comment:
     description:

--- a/plugins/modules/nios_host_record.py
+++ b/plugins/modules/nios_host_record.py
@@ -203,6 +203,11 @@ options:
       - Allows for the configuration of Extensible Attributes on the
         instance of the object.  This argument accepts a set of key / value
         pairs for configuration.
+      - A value may also be supplied as a dictionary to control inheritance of
+        an inheritable Extensible Attribute. Such a dictionary accepts a
+        C(value) key together with an C(inheritance_operation) key set to
+        C(INHERIT) to revert the object to its inherited value, or C(OVERRIDE)
+        to explicitly override an inherited value.
     type: dict
   comment:
     description:

--- a/plugins/modules/nios_network.py
+++ b/plugins/modules/nios_network.py
@@ -109,6 +109,11 @@ options:
       - Allows for the configuration of Extensible Attributes on the
         instance of the object.  This argument accepts a set of key / value
         pairs for configuration.
+      - A value may also be supplied as a dictionary to control inheritance of
+        an inheritable Extensible Attribute. Such a dictionary accepts a
+        C(value) key together with an C(inheritance_operation) key set to
+        C(INHERIT) to revert the object to its inherited value, or C(OVERRIDE)
+        to explicitly override an inherited value.
     type: dict
   comment:
     description:

--- a/plugins/modules/nios_zone.py
+++ b/plugins/modules/nios_zone.py
@@ -84,6 +84,11 @@ options:
       - Allows for the configuration of Extensible Attributes on the
         instance of the object.  This argument accepts a set of key / value
         pairs for configuration.
+      - A value may also be supplied as a dictionary to control inheritance of
+        an inheritable Extensible Attribute. Such a dictionary accepts a
+        C(value) key together with an C(inheritance_operation) key set to
+        C(INHERIT) to revert the object to its inherited value, or C(OVERRIDE)
+        to explicitly override an inherited value.
     type: dict
   comment:
     description:

--- a/tests/unit/plugins/module_utils/test_api.py
+++ b/tests/unit/plugins/module_utils/test_api.py
@@ -183,6 +183,101 @@ class TestNiosApi(unittest.TestCase):
         self.assertFalse(res['changed'])
         wapi.update_object.assert_not_called()
 
+    def test_normalize_extattrs_flat_and_structured(self):
+        # flat scalar -> wrapped in {'value': ...}
+        self.assertEqual(
+            api.normalize_extattrs({'Site': 'test'}),
+            {'Site': {'value': 'test'}})
+        # structured value with inheritance control is passed through as-is
+        self.assertEqual(
+            api.normalize_extattrs({'Site': {'value': 'test', 'inheritance_operation': 'INHERIT'}}),
+            {'Site': {'value': 'test', 'inheritance_operation': 'INHERIT'}})
+        # read-only inheritance_source is stripped before sending to WAPI
+        self.assertEqual(
+            api.normalize_extattrs({'Site': {'value': 'test', 'inheritance_source': {'_ref': 'x'}}}),
+            {'Site': {'value': 'test'}})
+
+    def test_flatten_extattrs_preserves_inheritance(self):
+        # plain value flattens to scalar
+        self.assertEqual(
+            api.flatten_extattrs({'Site': {'value': 'test'}}),
+            {'Site': 'test'})
+        # inherited value keeps its inheritance metadata
+        inherited = {'Site': {'value': 'test', 'inheritance_source': {'_ref': 'x'}}}
+        self.assertEqual(api.flatten_extattrs(inherited), inherited)
+
+    def test_wapi_extattrs_inheritance_override_change(self):
+        # current value is inherited; proposing an explicit value must override.
+        self.module.params = {'provider': None, 'state': 'present', 'name': 'default',
+                              'comment': 'test comment',
+                              'extattrs': {'Site': 'child-value'}}
+
+        ref = "networkview/ZG5zLm5ldHdvcmtfdmlldyQw:default/true"
+        test_object = [{
+            "comment": "test comment",
+            "_ref": ref,
+            "name": "default",
+            "extattrs": {'Site': {'value': 'parent-value',
+                                  'inheritance_source': {'_ref': 'networkcontainer/x'}}}
+        }]
+
+        test_spec = {"name": {"ib_req": True}, "comment": {}, "extattrs": {}}
+
+        wapi = self._get_wapi(test_object)
+        res = wapi.run('testobject', test_spec)
+
+        self.assertTrue(res['changed'])
+        wapi.update_object.assert_called_once()
+
+    def test_wapi_extattrs_inheritance_inherit_nochange(self):
+        # current value is already inherited; proposing INHERIT is idempotent.
+        self.module.params = {'provider': None, 'state': 'present', 'name': 'default',
+                              'comment': 'test comment',
+                              'extattrs': {'Site': {'value': 'parent-value',
+                                                    'inheritance_operation': 'INHERIT'}}}
+
+        ref = "networkview/ZG5zLm5ldHdvcmtfdmlldyQw:default/true"
+        test_object = [{
+            "comment": "test comment",
+            "_ref": ref,
+            "name": "default",
+            "extattrs": {'Site': {'value': 'parent-value',
+                                  'inheritance_source': {'_ref': 'networkcontainer/x'}}}
+        }]
+
+        test_spec = {"name": {"ib_req": True}, "comment": {}, "extattrs": {}}
+
+        wapi = self._get_wapi(test_object)
+        res = wapi.run('testobject', test_spec)
+
+        self.assertFalse(res['changed'])
+        wapi.update_object.assert_not_called()
+
+    def test_wapi_extattrs_inheritance_inherit_change(self):
+        # current value is explicitly set; proposing INHERIT must revert it.
+        self.module.params = {'provider': None, 'state': 'present', 'name': 'default',
+                              'comment': 'test comment',
+                              'extattrs': {'Site': {'value': 'parent-value',
+                                                    'inheritance_operation': 'INHERIT'}}}
+
+        ref = "networkview/ZG5zLm5ldHdvcmtfdmlldyQw:default/true"
+        test_object = [{
+            "comment": "test comment",
+            "_ref": ref,
+            "name": "default",
+            "extattrs": {'Site': {'value': 'child-value'}}
+        }]
+
+        test_spec = {"name": {"ib_req": True}, "comment": {}, "extattrs": {}}
+
+        wapi = self._get_wapi(test_object)
+        res = wapi.run('testobject', test_spec)
+
+        self.assertTrue(res['changed'])
+        # the inheritance_operation must be forwarded to WAPI on update
+        args = wapi.update_object.call_args[0]
+        self.assertEqual(args[1]['extattrs']['Site'].get('inheritance_operation'), 'INHERIT')
+
     def test_wapi_create(self):
         self.module.params = {'provider': None, 'state': 'present', 'name': 'ansible',
                               'comment': None, 'extattrs': None}


### PR DESCRIPTION
## Summary

Fixes #82 — extensible attribute (EA) inheritance could not be controlled from the collection.

EA values were only accepted as flat key/value pairs. `normalize_extattrs` wrapped every value in a `value` dict, so a structured value carrying inheritance control (e.g. `inheritance_operation`) was double-nested and rejected by WAPI with **`Bad value for extensible attribute`**. `flatten_extattrs` also silently dropped the `inheritance_source` struct WAPI returns for inherited values.

## Changes

- **`normalize_extattrs`** — a dict value is now passed through as-is (only the read-only `inheritance_source` is stripped, since WAPI rejects it on write); scalars are still wrapped in `{value: ...}` (unchanged behaviour).
- **`flatten_extattrs`** — preserves the full struct when it carries `inheritance_source`, so an inherited value stays visible and comparable; plain values still flatten to a scalar.
- **`compare_extattrs`** — understands `INHERIT` / `OVERRIDE` semantics for idempotency and is now authoritative for the `extattrs` key (skips the generic recursion that otherwise misreported inheritance fields).
- Documented the capability on `nios_network`, added `playbooks/extattrs_inheritance.yml`, unit tests, and a changelog fragment.

### Usage

```yaml
# Revert a child object to its inherited value
extattrs:
  Site:
    value: HQ            # required by WAPI, ignored for INHERIT
    inheritance_operation: INHERIT

# Explicitly override an inherited value
extattrs:
  Site:
    value: Branch
    inheritance_operation: OVERRIDE

# Flat form still works exactly as before
extattrs:
  Site: Branch
```

## Testing

Verified end-to-end against a live NIOS grid (WAPI 2.12.3) with an inheritable EA definition:

| Scenario | Before fix | After fix |
|----------|-----------|-----------|
| Revert override → inheritance (`INHERIT`) | ❌ `Bad value for extensible attribute` | ✅ applied, idempotent on re-run |
| Override inherited value (structured `OVERRIDE`) | ❌ rejected | ✅ applied, idempotent |
| Override inherited value (flat) | ✅ | ✅ idempotent |
| Plain EA set (regression) | ✅ | ✅ idempotent |

- `ansible-test units --python 3.13` — all unit tests pass (module_utils, modules, lookup, inventory), incl. 5 new cases.
- `ansible-test sanity --python 3.13` — clean.

## Backward compatibility

Flat EA usage is unchanged. Only inherited EAs now surface their `inheritance_source` on read (an improvement; previously it was silently discarded).
