### PR TITLE
Fix NPA-1969: nios_dtc_monitor_http not idempotent with request field

### DIFF
--- a/plugins/module_utils/api.py
+++ b/plugins/module_utils/api.py
@@ -984,6 +984,21 @@ class WapiModule(WapiBase):
                 return False
         return True
 
+    @staticmethod
+    def normalize_http_request(value):
+        ''' Normalize a dtc:monitor:http request value for idempotent comparison.
+
+        NIOS auto-appends '\nConnection: close\n\n' to the stored request, so a
+        read-back never matches the user-supplied value verbatim. Strip that
+        trailing header and surrounding whitespace before comparing.
+        '''
+        if not isinstance(value, str):
+            return value
+        normalized = value.rstrip()
+        if normalized.endswith('Connection: close'):
+            normalized = normalized[:-len('Connection: close')].rstrip()
+        return normalized
+
     def compare_objects(self, current_object, proposed_object, ib_obj_type=None):
         for key, proposed_item in proposed_object.items():
             current_item = current_object.get(key)
@@ -1081,7 +1096,14 @@ class WapiModule(WapiBase):
                     continue
 
             else:
-                if current_item != proposed_item:
+                # NIOS auto-appends '\nConnection: close\n\n' to the
+                # dtc:monitor:http request field, so the read-back never matches
+                # the user input verbatim. Normalize both sides before comparing
+                # to keep the module idempotent.
+                if ib_obj_type == NIOS_DTC_MONITOR_HTTP and key == 'request':
+                    if self.normalize_http_request(current_item) != self.normalize_http_request(proposed_item):
+                        return False
+                elif current_item != proposed_item:
                     return False
 
         return True

--- a/tests/integration/targets/nios_dtc_monitor_http/tasks/nios_dtc_monitor_http_idempotence.yaml
+++ b/tests/integration/targets/nios_dtc_monitor_http/tasks/nios_dtc_monitor_http_idempotence.yaml
@@ -51,6 +51,22 @@
     provider: "{{ nios_provider }}"
   register: dtc_monitor_http_update2
 
+- name: Create a DTC HTTP monitor with a custom request
+  infoblox.nios_modules.nios_dtc_monitor_http:
+    name: https_monitor
+    request: "GET /health HTTP/1.1"
+    state: present
+    provider: "{{ nios_provider }}"
+  register: dtc_monitor_http_request1
+
+- name: Recreate the DTC HTTP monitor with the same request (expect no change)
+  infoblox.nios_modules.nios_dtc_monitor_http:
+    name: https_monitor
+    request: "GET /health HTTP/1.1"
+    state: present
+    provider: "{{ nios_provider }}"
+  register: dtc_monitor_http_request2
+
 - name: Remove a DTC HTTPS monitor from the system
   infoblox.nios_modules.nios_dtc_monitor_http:
     name: https_monitor
@@ -72,5 +88,7 @@
       - not dtc_monitor_http_create2.changed
       - dtc_monitor_http_update1.changed
       - not dtc_monitor_http_update2.changed
+      - dtc_monitor_http_request1.changed
+      - not dtc_monitor_http_request2.changed
       - dtc_monitor_http_delete1.changed
       - not dtc_monitor_http_delete2.changed

--- a/tests/unit/plugins/modules/test_nios_dtc_monitor_http.py
+++ b/tests/unit/plugins/modules/test_nios_dtc_monitor_http.py
@@ -135,3 +135,47 @@ class TestNiosDtcHttpMonitorModule(TestNiosModule):
 
         self.assertTrue(res['changed'])
         wapi.delete_object.assert_called_once_with(ref)
+
+    def test_nios_dtc_monitor_http_idempotency_with_request_field(self):
+        """Test that monitor with request field is idempotent.
+
+        NIOS automatically appends '\nConnection: close\n\n' to the request value.
+        The module should recognize this as idempotent on re-apply.
+        """
+        self.module.params = {'provider': None, 'state': 'present', 'name': 'idempotency_bug_test',
+                              'request': 'GET /health HTTP/1.1', 'port': 80, 'extattrs': None,
+                              'comment': None}
+
+        ref = "dtc:monitor:http/ZG5zLmlkbnNfbW9uaXRvcl9odHRwJGlkZW1wb3RlbmN5X2J1Z190ZXN0:idempotency_bug_test"
+
+        # This is what NIOS returns - with appended Connection: close header
+        test_object = [
+            {
+                "_ref": ref,
+                "name": "idempotency_bug_test",
+                "request": "GET /health HTTP/1.1\nConnection: close\n\n",
+                "port": 80,
+                "interval": 5,
+                "timeout": 15,
+                "result": "ANY",
+                "result_code": 200,
+                "secure": False,
+                "extattrs": {}
+            }
+        ]
+
+        test_spec = {
+            "name": {"ib_req": True},
+            "request": {},
+            "port": {},
+            "extattrs": {},
+            "comment": {}
+        }
+
+        wapi = self._get_wapi(test_object)
+        res = wapi.run('dtc:monitor:http', test_spec)
+
+        # Should be idempotent - changed should be False
+        self.assertFalse(res['changed'])
+        # update_object should not be called since there are no changes
+        wapi.update_object.assert_not_called()


### PR DESCRIPTION
NIOS automatically appends '\nConnection: close\n\n' to the HTTP request field, so the read-back never matches the user-supplied input, causing the module to report changed=true on every re-apply even when nothing changed.

compare_objects() now normalizes the dtc:monitor:http request field via a dedicated normalize_http_request() helper that strips the trailing 'Connection: close' header and surrounding whitespace before comparison. The normalization is scoped to NIOS_DTC_MONITOR_HTTP objects only, leaving all other object types untouched.

Adds a unit test for the request-field idempotency case and extends the integration idempotence suite to exercise a custom request value.