### PR TITLE
Fix nios_nsgroup extattrs crash and TSIG idempotency (NPA-1975, NPA-1…

### DIFF
--- a/changelogs/fragments/nios_nsgroup-extattrs-and-tsig-idempotency.yml
+++ b/changelogs/fragments/nios_nsgroup-extattrs-and-tsig-idempotency.yml
@@ -1,0 +1,16 @@
+---
+bugfixes:
+  - nios_nsgroup - fix an ``AttributeError`` crash
+    (``'str' object has no attribute 'items'``) when ``extattrs`` is supplied.
+    The argument was declared without a type, so Ansible defaulted it to
+    ``str`` and coerced the supplied dictionary into its string
+    representation, which later failed in ``normalize_extattrs``. ``extattrs``
+    is now declared as ``type=dict``.
+  - nios_nsgroup - fix idempotency when a TSIG key is configured on an
+    ``external_primaries``, ``external_secondaries`` or member
+    ``preferred_primaries`` nameserver. ``tsig_key`` is write-only (never
+    returned by NIOS on read) and a supplied ``tsig_key_name`` is stored as the
+    ``use_tsig_key_name`` flag, so the proposed-vs-current comparison always
+    reported ``changed=true`` on re-apply. Those TSIG fields are now
+    canonicalized before comparison, while the key material is still sent on
+    create and update.

--- a/plugins/module_utils/api.py
+++ b/plugins/module_utils/api.py
@@ -202,6 +202,53 @@ def normalize_extattrs(value):
     return normalized
 
 
+# nsgroup fields that hold lists of nameserver structs which may carry TSIG
+# configuration (directly or, for grid members, via preferred_primaries).
+NIOS_NSGROUP_SERVER_LISTS = (
+    'external_primaries', 'external_secondaries', 'grid_primary', 'grid_secondaries')
+
+
+def _canonicalize_tsig(server):
+    ''' Canonicalize the TSIG fields of a single nameserver struct in place.
+
+    tsig_key is write-only: WAPI never returns the key material on read and
+    Ansible masks it in output, so it must be dropped before comparison. WAPI
+    also stores a supplied tsig_key_name as the boolean use_tsig_key_name flag
+    (returning use_tsig_key_name=true rather than the name), so rewrite the
+    name to that flag to match the read-back representation.
+    '''
+    if not isinstance(server, dict):
+        return
+    server.pop('tsig_key', None)
+    if server.get('tsig_key_name'):
+        server['use_tsig_key_name'] = True
+        server.pop('tsig_key_name', None)
+
+
+def normalize_nsgroup_tsig(obj):
+    ''' Return a deep copy of an nsgroup object with TSIG fields canonicalized.
+
+    Applied to both the proposed and current objects so that a re-applied
+    nsgroup carrying TSIG-secured nameservers compares equal and stays
+    idempotent. The original object is left untouched so the create/update
+    payload still carries the real tsig_key/tsig_key_name.
+    '''
+    if not isinstance(obj, dict):
+        return obj
+    normalized = copy.deepcopy(obj)
+    for field in NIOS_NSGROUP_SERVER_LISTS:
+        servers = normalized.get(field)
+        if not isinstance(servers, list):
+            continue
+        for server in servers:
+            _canonicalize_tsig(server)
+            # grid members nest external servers under preferred_primaries.
+            if isinstance(server, dict):
+                for ext in server.get('preferred_primaries') or []:
+                    _canonicalize_tsig(ext)
+    return normalized
+
+
 def flatten_extattrs(value):
     ''' Flatten the key/value struct for extattrs
     WAPI returns extattrs field as a dict in form of:
@@ -727,7 +774,15 @@ class WapiModule(WapiBase):
             proposed_for_compare = {k: v for k, v in proposed_object.items() if k != 'password'}
         else:
             proposed_for_compare = proposed_object
-        modified = not self.compare_objects(current_object, proposed_for_compare, ib_obj_type)
+        current_for_compare = current_object
+        # TSIG key material is write-only and WAPI represents a supplied
+        # tsig_key_name as the use_tsig_key_name flag on read-back, so a
+        # verbatim comparison always reports changed=True. Canonicalize both
+        # sides (on copies) so re-applying a TSIG-secured nsgroup is idempotent.
+        if ib_obj_type == NIOS_NSGROUP:
+            proposed_for_compare = normalize_nsgroup_tsig(proposed_for_compare)
+            current_for_compare = normalize_nsgroup_tsig(current_object)
+        modified = not self.compare_objects(current_for_compare, proposed_for_compare, ib_obj_type)
         if 'extattrs' in proposed_object:
             proposed_object['extattrs'] = normalize_extattrs(proposed_object['extattrs'])
 

--- a/plugins/modules/nios_nsgroup.py
+++ b/plugins/modules/nios_nsgroup.py
@@ -255,7 +255,7 @@ options:
       - Allows for the configuration of Extensible Attributes on the
         instance of the object.  This argument accepts a set of key / value
         pairs for configuration.
-    type: str
+    type: dict
   comment:
     description:
       - Configures a text string comment to be associated with the instance
@@ -424,7 +424,7 @@ def main():
                                   transform=ext_secondaries_transform),
         is_grid_default=dict(type='bool', default=False),
         use_external_primary=dict(type='bool', default=False),
-        extattrs=dict(),
+        extattrs=dict(type='dict'),
         comment=dict(),
     )
 

--- a/tests/unit/plugins/modules/test_nios_nsgroup.py
+++ b/tests/unit/plugins/modules/test_nios_nsgroup.py
@@ -287,3 +287,103 @@ class TestNiosNSGroupModule(TestNiosModule):
         })
         with self.assertRaises(AnsibleExitJson):
             nios_nsgroup.main()
+
+    # ------------------------------------------------------------------
+    # extattrs must be declared as type='dict'. Previously the spec used
+    # extattrs=dict() (no type), so AnsibleModule defaulted it to 'str' and
+    # coerced a supplied dict into its string repr, crashing later in
+    # normalize_extattrs with "'str' object has no attribute 'items'".
+    # ------------------------------------------------------------------
+
+    def test_nios_nsgroup_extattrs_declared_as_dict(self):
+        '''extattrs must be parsed as a dict, not coerced to a string.'''
+        set_module_args({
+            'name': 'test-group',
+            'state': 'present',
+            'grid_primary': [{'name': 'infoblox.member'}],
+            'extattrs': {'Site': 'Test-Ansible'},
+            'provider': {'host': '192.168.1.1', 'username': 'admin', 'password': 'admin'},
+        })
+        with self.assertRaises(AnsibleExitJson):
+            nios_nsgroup.main()
+        # main() builds the argument_spec and hands the real AnsibleModule to
+        # WapiModule(); inspect it to prove extattrs is a dict-typed argument
+        # and that a supplied dict survives parsing intact.
+        called_module = self.exec_command.call_args[0][0]
+        self.assertEqual(called_module.argument_spec['extattrs'].get('type'), 'dict')
+        self.assertEqual(called_module.params['extattrs'], {'Site': 'Test-Ansible'})
+
+    # ------------------------------------------------------------------
+    # Re-applying an nsgroup with a TSIG-secured external server must be
+    # idempotent. tsig_key is write-only (never returned on read) and WAPI
+    # stores a supplied tsig_key_name as the use_tsig_key_name flag, so a
+    # verbatim comparison wrongly reported changed=true on every re-run.
+    # ------------------------------------------------------------------
+
+    def test_nios_nsgroup_tsig_external_secondary_idempotent(self):
+        '''Identical TSIG external_secondaries must NOT trigger an update.'''
+        ref = "nsgroup/ZG5zLm5ldHdvcmtfdmlldyQw:test-group/false"
+        self.module.params = {
+            'provider': None, 'state': 'present', 'name': 'test-group',
+            'comment': None, 'grid_primary': None, 'grid_secondaries': None,
+            'external_primaries': None,
+            'external_secondaries': [
+                {'address': '192.168.100.5', 'name': 'ext-tsig-ns', 'stealth': False,
+                 'tsig_key_name': 'test-tsig-key', 'tsig_key': 'aGVsbG93b3JsZA==',
+                 'tsig_key_alg': 'HMAC-MD5'},
+            ],
+            'is_grid_default': False, 'use_external_primary': False,
+            'extattrs': None,
+        }
+        # Mirror WAPI's read-back: tsig_key is never returned and the supplied
+        # tsig_key_name surfaces as use_tsig_key_name=True.
+        test_object = [{
+            '_ref': ref,
+            'name': 'test-group',
+            'external_secondaries': [
+                {'address': '192.168.100.5', 'name': 'ext-tsig-ns', 'stealth': False,
+                 'tsig_key_alg': 'HMAC-MD5', 'use_tsig_key_name': True},
+            ],
+        }]
+        test_spec = {
+            'name': {'ib_req': True},
+            'comment': {},
+            'external_secondaries': {'type': 'list'},
+        }
+        wapi = self._get_wapi(test_object)
+        res = wapi.run(api.NIOS_NSGROUP, test_spec)
+        self.assertFalse(res['changed'])
+        wapi.update_object.assert_not_called()
+
+    def test_nios_nsgroup_tsig_external_secondary_change_detected(self):
+        '''A genuine non-TSIG change on a TSIG server must still update.'''
+        ref = "nsgroup/ZG5zLm5ldHdvcmtfdmlldyQw:test-group/false"
+        self.module.params = {
+            'provider': None, 'state': 'present', 'name': 'test-group',
+            'comment': None, 'grid_primary': None, 'grid_secondaries': None,
+            'external_primaries': None,
+            'external_secondaries': [
+                {'address': '192.168.100.9', 'name': 'ext-tsig-ns', 'stealth': False,
+                 'tsig_key_name': 'test-tsig-key', 'tsig_key': 'aGVsbG93b3JsZA==',
+                 'tsig_key_alg': 'HMAC-MD5'},
+            ],
+            'is_grid_default': False, 'use_external_primary': False,
+            'extattrs': None,
+        }
+        test_object = [{
+            '_ref': ref,
+            'name': 'test-group',
+            'external_secondaries': [
+                {'address': '192.168.100.5', 'name': 'ext-tsig-ns', 'stealth': False,
+                 'tsig_key_alg': 'HMAC-MD5', 'use_tsig_key_name': True},
+            ],
+        }]
+        test_spec = {
+            'name': {'ib_req': True},
+            'comment': {},
+            'external_secondaries': {'type': 'list'},
+        }
+        wapi = self._get_wapi(test_object)
+        res = wapi.run(api.NIOS_NSGROUP, test_spec)
+        self.assertTrue(res['changed'])
+        wapi.update_object.assert_called_once()


### PR DESCRIPTION
…976)

NPA-1975: extattrs was declared as extattrs=dict() with no type, so AnsibleModule defaulted it to str and coerced a supplied dict into its string repr, crashing in normalize_extattrs with "'str' object has no attribute 'items'". Declare extattrs as type=dict (spec + DOCUMENTATION).

NPA-1976: re-applying an nsgroup with a TSIG-secured external/grid nameserver always reported changed=true. tsig_key is write-only (never returned on read) and WAPI stores a supplied tsig_key_name as the use_tsig_key_name flag, so the proposed-vs-current diff never matched. Canonicalize those TSIG fields on copies of both sides before comparison while still sending the key material on create/update.

Add unit tests covering both fixes and a changelog fragment.