### PR TITLE
Fixed result.msg, now contains the actual error reason

### DIFF
--- a/plugins/module_utils/api.py
+++ b/plugins/module_utils/api.py
@@ -596,8 +596,11 @@ class WapiModule(WapiBase):
                 and obj_filter.get('view') == 'default'):
             retry_filter = dict(obj_filter)
             retry_filter.pop('view', None)
-            retry_obj_ref, retry_update, retry_new_name = self.get_object_ref(
-                self.module, ib_obj_type, retry_filter, ib_spec)
+            try:
+                retry_obj_ref, retry_update, retry_new_name = self.get_object_ref(
+                    self.module, ib_obj_type, retry_filter, ib_spec)
+            except Exception as exc:
+                self.module.fail_json(msg=to_native(exc))
             if retry_obj_ref:
                 ipam_only = [
                     rec for rec in retry_obj_ref
@@ -948,13 +951,16 @@ class WapiModule(WapiBase):
     def get_network_view(self, proposed_object):
         ''' Check for the associated network view with
             the given dns_view'''
+        view_name = proposed_object.get('view') if isinstance(proposed_object, dict) else None
+        if not view_name:
+            self.module.fail_json(msg="dns_view is required to look up the associated network view")
         try:
-            network_view_ref = self.get_object('view', {"name": proposed_object['view']}, return_fields=['network_view'])
-            if network_view_ref:
-                network_view = network_view_ref[0].get('network_view')
-                return network_view
+            network_view_ref = self.get_object('view', {"name": view_name}, return_fields=['network_view'])
         except Exception:
-            self.module.fail_json(msg="object with dns_view: %s not found" % (proposed_object['view']))
+            self.module.fail_json(msg="object with dns_view: %s not found" % view_name)
+        if not network_view_ref:
+            self.module.fail_json(msg="object with dns_view: %s not found" % view_name)
+        return network_view_ref[0].get('network_view')
 
     def check_if_nios_next_ip_exists(self, proposed_object):
         ''' Check if nios_next_ip argument is passed in ipaddr while creating
@@ -1307,7 +1313,7 @@ class WapiModule(WapiBase):
                         ib_obj = ipam_only or None
                 if ib_obj:
                     obj_filter['name'] = new_name
-                elif old_ipv4addr_exists and (len(ib_obj) == 0):
+                elif old_ipv4addr_exists and (not ib_obj):
                     self.module.fail_json(
                         msg="object with name: '%s', ipv4addr: '%s' is not found" % (old_name, test_obj_filter['ipv4addr']))
                 else:

--- a/plugins/module_utils/api.py
+++ b/plugins/module_utils/api.py
@@ -577,7 +577,10 @@ class WapiModule(WapiBase):
 
         obj_filter = dict([(k, self.module.params[k]) for k, v in ib_spec.items() if v.get('ib_req')])
         # get object reference
-        ib_obj_ref, update, new_name = self.get_object_ref(self.module, ib_obj_type, obj_filter, ib_spec)
+        try:
+            ib_obj_ref, update, new_name = self.get_object_ref(self.module, ib_obj_type, obj_filter, ib_spec)
+        except Exception as exc:
+            self.module.fail_json(msg=to_native(exc))
 
         # Issue #300: IPAM-only host records carry view=' ' in WAPI. If the user
         # calls state=absent (or update) without specifying a view, our search
@@ -951,7 +954,7 @@ class WapiModule(WapiBase):
                 network_view = network_view_ref[0].get('network_view')
                 return network_view
         except Exception:
-            raise Exception("object with dns_view: %s not found" % (proposed_object['view']))
+            self.module.fail_json(msg="object with dns_view: %s not found" % (proposed_object['view']))
 
     def check_if_nios_next_ip_exists(self, proposed_object):
         ''' Check if nios_next_ip argument is passed in ipaddr while creating
@@ -1305,10 +1308,10 @@ class WapiModule(WapiBase):
                 if ib_obj:
                     obj_filter['name'] = new_name
                 elif old_ipv4addr_exists and (len(ib_obj) == 0):
-                    raise Exception(
-                        "object with name: '%s', ipv4addr: '%s' is not found" % (old_name, test_obj_filter['ipv4addr']))
+                    self.module.fail_json(
+                        msg="object with name: '%s', ipv4addr: '%s' is not found" % (old_name, test_obj_filter['ipv4addr']))
                 else:
-                    raise Exception("object with name: '%s' is not found" % (old_name))
+                    self.module.fail_json(msg="object with name: '%s' is not found" % (old_name))
                 update = True
                 return ib_obj, update, new_name
             if (ib_obj_type == NIOS_HOST_RECORD):
@@ -1481,10 +1484,10 @@ class WapiModule(WapiBase):
 
             # prevents creation of a new A record with 'new_ipv4addr' when A record with a particular 'old_ipv4addr' is not found
             if old_ipv4addr_exists and (ib_obj is None or len(ib_obj) == 0):
-                raise Exception("A Record with ipv4addr: '%s' is not found" % (ipaddr))
+                self.module.fail_json(msg="A Record with ipv4addr: '%s' is not found" % (ipaddr))
             # prevents creation of a new TXT record with 'new_text' when TXT record with a particular 'old_text' is not found
             if old_text_exists and ib_obj is None:
-                raise Exception("TXT Record with text: '%s' is not found" % (txt))
+                self.module.fail_json(msg="TXT Record with text: '%s' is not found" % (txt))
         elif (ib_obj_type == NIOS_A_RECORD):
             # resolves issue where multiple a_records with same name and different IP address
             test_obj_filter = obj_filter
@@ -1498,7 +1501,7 @@ class WapiModule(WapiBase):
             ib_obj = self.get_object(ib_obj_type, test_obj_filter.copy(), return_fields=list(ib_spec.keys()))
             # prevents creation of a new A record with 'new_ipv4addr' when A record with a particular 'old_ipv4addr' is not found
             if old_ipv4addr_exists and ib_obj is None:
-                raise Exception("A Record with ipv4addr: '%s' is not found" % (ipaddr))
+                self.module.fail_json(msg="A Record with ipv4addr: '%s' is not found" % (ipaddr))
         elif (ib_obj_type == NIOS_TXT_RECORD):
             # resolves issue where multiple txt_records with same name and different text
             test_obj_filter = obj_filter
@@ -1526,7 +1529,7 @@ class WapiModule(WapiBase):
             ib_obj = self.get_object(ib_obj_type, test_obj_filter.copy(), return_fields=list(ib_spec.keys()))
             # prevents creation of a new TXT record with 'new_text' when TXT record with a particular 'old_text' is not found
             if old_text_exists and ib_obj is None:
-                raise Exception("TXT Record with text: '%s' is not found" % (txt))
+                self.module.fail_json(msg="TXT Record with text: '%s' is not found" % (txt))
         elif (ib_obj_type == NIOS_ZONE):
             # del key 'restart_if_needed' as nios_zone get_object fails with the key present
             temp = ib_spec['restart_if_needed']
@@ -1556,7 +1559,7 @@ class WapiModule(WapiBase):
                 if ib_obj:
                     obj_filter['host_name'] = new_name
                 else:
-                    raise Exception("object with name: '%s' is not found" % (old_name))
+                    self.module.fail_json(msg="object with name: '%s' is not found" % (old_name))
                 update = True
             else:
                 # del key 'create_token' as nios_member get_object fails with the key present
@@ -1623,8 +1626,8 @@ class WapiModule(WapiBase):
             # throws exception if start_addr and end_addr doesn't exists for updating range
             if (new_start_arg and new_end_arg):
                 if not ib_obj:
-                    raise Exception(
-                        'Specified range %s-%s not found' % (obj_filter['start_addr'], obj_filter['end_addr']))
+                    self.module.fail_json(
+                        msg='Specified range %s-%s not found' % (obj_filter['start_addr'], obj_filter['end_addr']))
         else:
             ib_obj = self.get_object(ib_obj_type, obj_filter.copy(), return_fields=list(ib_spec.keys()))
         return ib_obj, update, new_name


### PR DESCRIPTION
This pull request refactors error handling in the `plugins/module_utils/api.py` module to improve consistency and reliability. Instead of raising generic exceptions, the code now uses the Ansible-specific `fail_json` method to report errors, ensuring that error messages are properly formatted and surfaced to users in a way that integrates with Ansible's error reporting.

**Error handling improvements:**

* Replaced all instances of `raise Exception` with `self.module.fail_json(msg=...)` in the `get_object_ref` and `get_network_view` methods, ensuring consistent error reporting through Ansible's mechanisms. [[1]](diffhunk://#diff-cde08f2d51a35784dd838d4e7325299be0903a897357bc900d34e42a11b03f14L1308-R1314) [[2]](diffhunk://#diff-cde08f2d51a35784dd838d4e7325299be0903a897357bc900d34e42a11b03f14L1484-R1490) [[3]](diffhunk://#diff-cde08f2d51a35784dd838d4e7325299be0903a897357bc900d34e42a11b03f14L1501-R1504) [[4]](diffhunk://#diff-cde08f2d51a35784dd838d4e7325299be0903a897357bc900d34e42a11b03f14L1529-R1532) [[5]](diffhunk://#diff-cde08f2d51a35784dd838d4e7325299be0903a897357bc900d34e42a11b03f14L1559-R1562) [[6]](diffhunk://#diff-cde08f2d51a35784dd838d4e7325299be0903a897357bc900d34e42a11b03f14L1626-R1630) [[7]](diffhunk://#diff-cde08f2d51a35784dd838d4e7325299be0903a897357bc900d34e42a11b03f14L954-R957)

* Wrapped the call to `get_object_ref` in the `run` method in a try/except block, using `self.module.fail_json` to handle any exceptions and provide user-friendly error messages.

These changes make error handling more robust and user-friendly in Ansible modules that use this utility.