### PR TITLE
 Fix check mode change reporting for state: absent

### DIFF
--- a/plugins/module_utils/api.py
+++ b/plugins/module_utils/api.py
@@ -884,8 +884,9 @@ class WapiModule(WapiBase):
                         if not self.module.check_mode:
                             self.update_object(ref, proposed_object)
                         result['changed'] = True
-                elif not self.module.check_mode:
-                    self.delete_object(ref)
+                else:
+                    if not self.module.check_mode:
+                        self.delete_object(ref)
                     result['changed'] = True
 
         # ------------------------------------------------------------------


### PR DESCRIPTION
result['changed'] = True was indented inside the [if not self.module.check_mode:] block, so it never fired during a dry-run, making state: absent + check_mode: true silently report changed=False instead of changed=True.