### PR TITLE
fix(nios_fixed_address): strip use_option=false options before idempo…

### DIFF
--- a/plugins/module_utils/api.py
+++ b/plugins/module_utils/api.py
@@ -682,7 +682,8 @@ class WapiModule(WapiBase):
             current_object = convert_members_to_struct(current_object)
             current_object = convert_vlans_to_struct(current_object)
 
-        if ib_obj_type in {NIOS_IPV4_NETWORK_CONTAINER, NIOS_IPV6_NETWORK_CONTAINER, NIOS_IPV4_NETWORK, NIOS_IPV6_NETWORK, NIOS_RANGE}:
+        if ib_obj_type in {NIOS_IPV4_NETWORK_CONTAINER, NIOS_IPV6_NETWORK_CONTAINER, NIOS_IPV4_NETWORK, NIOS_IPV6_NETWORK, NIOS_RANGE,
+                           NIOS_IPV4_FIXED_ADDRESS, NIOS_IPV6_FIXED_ADDRESS}:
 
             # Iterate over each option and remove the 'num' key
             if current_object.get('options') or proposed_object.get('options'):


### PR DESCRIPTION
…tency compare

When options: [] is explicitly passed to nios_fixed_address, the module was always reporting changed=True because NIOS automatically injects a default dhcp-lease-time option (use_option: false) into every fixed address.

The existing strip loop that removes use_option=false entries before the comparison (api.py ~L685) already handled network/container/range objects but NIOS_IPV4_FIXED_ADDRESS and NIOS_IPV6_FIXED_ADDRESS were missing from the type set, so the injected default option always caused a false diff.

Fix: add NIOS_IPV4_FIXED_ADDRESS and NIOS_IPV6_FIXED_ADDRESS to the same
type set, making fixed address idempotent when options: [] is supplied.

Note: omitting options entirely (options not in task) was already idempotent because the transform returns None and options is excluded from proposed_object.

Fixes: NIOS-2006