### PR TITLE
fix(nios_txt_record): old_text guard checks ib_obj is None but get_ob…

### DIFF
--- a/plugins/module_utils/api.py
+++ b/plugins/module_utils/api.py
@@ -1548,7 +1548,8 @@ class WapiModule(WapiBase):
             if old_ipv6addr_exists and (ib_obj is None or len(ib_obj) == 0):
                 self.module.fail_json(msg="AAAA Record with ipv6addr: '%s' is not found" % (ipaddr))
             # prevents creation of a new TXT record with 'new_text' when TXT record with a particular 'old_text' is not found
-            if old_text_exists and ib_obj is None:
+            # Note: get_object returns [] (empty list) when not found, NOT None — both cases must be checked
+            if old_text_exists and (ib_obj is None or len(ib_obj) == 0):
                 self.module.fail_json(msg="TXT Record with text: '%s' is not found" % (txt))
         elif (ib_obj_type == NIOS_A_RECORD):
             # resolves issue where multiple a_records with same name and different IP address
@@ -1606,7 +1607,8 @@ class WapiModule(WapiBase):
             test_obj_filter['text'] = txt
             ib_obj = self.get_object(ib_obj_type, test_obj_filter.copy(), return_fields=list(ib_spec.keys()))
             # prevents creation of a new TXT record with 'new_text' when TXT record with a particular 'old_text' is not found
-            if old_text_exists and ib_obj is None:
+            # Note: get_object returns [] (empty list) when not found, NOT None — both cases must be checked
+            if old_text_exists and (ib_obj is None or len(ib_obj) == 0):
                 self.module.fail_json(msg="TXT Record with text: '%s' is not found" % (txt))
         elif (ib_obj_type == NIOS_ZONE):
             # del key 'restart_if_needed' as nios_zone get_object fails with the key present


### PR DESCRIPTION
…ject returns []

When updating a TXT record via text:{old_text:X, new_text:Y} and the record specified by old_text does not exist, the module was incorrectly creating a new TXT record with new_text instead of failing.

Root cause: get_object always returns a list ([] when not found), never None. The guard condition 'if old_text_exists and ib_obj is None' was always False when no record was found — so the guard never fired, the function returned with ref=None, and run() fell through to create_object with proposed_object['text'] already replaced by new_text.

The A record guard at the same location already correctly uses:
  if old_ipv4addr_exists and (ib_obj is None or len(ib_obj) == 0)

Fix: apply the same pattern to both TXT record guard locations (name- based lookup path and no-name lookup path), and convert raise Exception to self.module.fail_json for a clean Ansible task failure message.

Fixes: NIOS-2009