### PR TITLE
Fix NPA-1993: detect nios_dtc_topology rule reordering as a change

### DIFF
--- a/changelogs/fragments/NPA-1993-dtc-topology-rule-reorder.yml
+++ b/changelogs/fragments/NPA-1993-dtc-topology-rule-reorder.yml
@@ -1,0 +1,7 @@
+---
+bugfixes:
+  - nios_dtc_topology module - reordering the rules of an existing topology is
+    now detected as a change. Rule order sets the priority sequence, but the
+    idempotency comparison matched rules regardless of position, so a pure
+    reorder reported ``changed=false`` and silently kept the original order.
+    Topology rules are now compared positionally.

--- a/plugins/module_utils/api.py
+++ b/plugins/module_utils/api.py
@@ -1081,6 +1081,19 @@ class WapiModule(WapiBase):
                 if key in ('pools', 'servers', 'external_servers', 'list_values') and not self.verify_list_order(proposed_item, current_item):
                     return False
 
+                # Rule order is semantically significant for DTC topologies: it
+                # sets the rule priority sequence. The generic issubset() check
+                # below matches each proposed rule against the whole current
+                # list regardless of position, so a pure reorder would go
+                # undetected (changed=false). Enforce a positional match so a
+                # reorder is reported as a change.
+                if ib_obj_type == NIOS_DTC_TOPOLOGY and key == 'rules':
+                    if len(proposed_item) != len(current_item):
+                        return False
+                    for proposed_rule, current_rule in zip(proposed_item, current_item):
+                        if not self.issubset(proposed_rule, [current_rule]):
+                            return False
+
                 for subitem in proposed_item:
                     if not isinstance(subitem, dict):
                         continue  # Skip non-dict items

--- a/plugins/module_utils/api.py
+++ b/plugins/module_utils/api.py
@@ -1087,7 +1087,12 @@ class WapiModule(WapiBase):
                 # list regardless of position, so a pure reorder would go
                 # undetected (changed=false). Enforce a positional match so a
                 # reorder is reported as a change.
-                if ib_obj_type == NIOS_DTC_TOPOLOGY and key == 'rules':
+                #
+                # Only do this when rules are actually proposed. Omitting the
+                # rules option yields an empty proposed list, which historically
+                # means "do not manage rules" (idempotent); the length check
+                # must not treat that as a reorder and wipe the existing rules.
+                if ib_obj_type == NIOS_DTC_TOPOLOGY and key == 'rules' and proposed_item:
                     if len(proposed_item) != len(current_item):
                         return False
                     for proposed_rule, current_rule in zip(proposed_item, current_item):

--- a/tests/unit/plugins/modules/test_nios_dtc_topology.py
+++ b/tests/unit/plugins/modules/test_nios_dtc_topology.py
@@ -607,3 +607,23 @@ class TestNiosDtcTopologyModule(TestNiosModule):
         self.assertFalse(res['changed'],
                          'Re-applying the same rule order must be idempotent')
         wapi.update_object.assert_not_called()
+
+    def test_nios_dtc_topology_omitted_rules_idempotent(self):
+        """Omitting the rules option must not be treated as a reorder: the
+        transform yields an empty proposed rule list, which means "do not
+        manage rules". The positional reorder check must not fire on an empty
+        proposed list and wipe the existing rules (regression: a bare
+        re-apply reported changed=True and dropped the rules)."""
+        self.module.params = {'provider': None, 'state': 'present',
+                              'name': 'reorder_topo',
+                              'rules': [],
+                              'comment': None, 'extattrs': None}
+        test_object = self._existing_topology(['pool1', 'pool2', 'pool3'])
+        test_spec = {"name": {"ib_req": True}, "rules": {}, "comment": {}, "extattrs": {}}
+
+        wapi = self._get_wapi(test_object)
+        res = wapi.run(api.NIOS_DTC_TOPOLOGY, test_spec)
+
+        self.assertFalse(res['changed'],
+                         'Re-applying with rules omitted must be idempotent')
+        wapi.update_object.assert_not_called()

--- a/tests/unit/plugins/modules/test_nios_dtc_topology.py
+++ b/tests/unit/plugins/modules/test_nios_dtc_topology.py
@@ -534,3 +534,76 @@ class TestNiosDtcTopologyModule(TestNiosModule):
             nios_dtc_topology.build_topology_rules(module, wapi, rules, '2.14')
         dummy, kwargs = module.fail_json.call_args
         self.assertIn('missing_pool', kwargs['msg'])
+
+    def _existing_topology(self, ordered_pools):
+        """Build a NIOS GET response for a legacy (WAPI <= 2.13) topology whose
+        rules point at `ordered_pools`, in that order. Mirrors what the grid
+        returns: destination_link as an expanded object plus per-rule _ref."""
+        ref = "dtc:topology/ZG5zLm5ldHdvcmtfdmlldyQw:reorder_topo"
+        subnets = {
+            'pool1': '10.0.0.0/8',
+            'pool2': '172.16.0.0/12',
+            'pool3': '192.168.0.0/16',
+        }
+        rules = []
+        for pool in ordered_pools:
+            rules.append({
+                '_ref': 'dtc:topology:rule/abc:reorder_topo/%s' % pool,
+                'dest_type': 'POOL',
+                'return_type': 'REGULAR',
+                'destination_link': {'_ref': 'dtc:pool/abc:%s' % pool, 'name': pool},
+                'sources': [{'source_op': 'IS', 'source_type': 'SUBNET',
+                             'source_value': subnets[pool]}],
+            })
+        return [{'_ref': ref, 'name': 'reorder_topo', 'rules': rules, 'extattrs': {}}]
+
+    def _proposed_rules(self, ordered_pools):
+        """Build the module's transformed (legacy) proposed rules for
+        `ordered_pools`, using bare destination_link references."""
+        subnets = {
+            'pool1': '10.0.0.0/8',
+            'pool2': '172.16.0.0/12',
+            'pool3': '192.168.0.0/16',
+        }
+        return [{
+            'dest_type': 'POOL',
+            'return_type': 'REGULAR',
+            'destination_link': 'dtc:pool/abc:%s' % pool,
+            'sources': [{'source_op': 'IS', 'source_type': 'SUBNET',
+                         'source_value': subnets[pool]}],
+        } for pool in ordered_pools]
+
+    def test_nios_dtc_topology_rule_reorder_detected(self):
+        """NPA-1993: reordering topology rules must be detected as a change.
+        Rule order sets the priority sequence, so it is semantically
+        significant and must trigger an update."""
+        self.module.params = {'provider': None, 'state': 'present',
+                              'name': 'reorder_topo',
+                              'rules': self._proposed_rules(['pool3', 'pool1', 'pool2']),
+                              'comment': None, 'extattrs': None}
+        test_object = self._existing_topology(['pool1', 'pool2', 'pool3'])
+        test_spec = {"name": {"ib_req": True}, "rules": {}, "comment": {}, "extattrs": {}}
+
+        wapi = self._get_wapi(test_object)
+        res = wapi.run(api.NIOS_DTC_TOPOLOGY, test_spec)
+
+        self.assertTrue(res['changed'],
+                        'Reordering topology rules must report changed=True')
+        wapi.update_object.assert_called_once()
+
+    def test_nios_dtc_topology_same_rule_order_idempotent(self):
+        """The reorder-detection fix must not introduce a false positive: an
+        unchanged rule order stays idempotent (changed=False)."""
+        self.module.params = {'provider': None, 'state': 'present',
+                              'name': 'reorder_topo',
+                              'rules': self._proposed_rules(['pool1', 'pool2', 'pool3']),
+                              'comment': None, 'extattrs': None}
+        test_object = self._existing_topology(['pool1', 'pool2', 'pool3'])
+        test_spec = {"name": {"ib_req": True}, "rules": {}, "comment": {}, "extattrs": {}}
+
+        wapi = self._get_wapi(test_object)
+        res = wapi.run(api.NIOS_DTC_TOPOLOGY, test_spec)
+
+        self.assertFalse(res['changed'],
+                         'Re-applying the same rule order must be idempotent')
+        wapi.update_object.assert_not_called()


### PR DESCRIPTION
Rule order in a DTC topology sets the priority sequence, so it is semantically significant. The idempotency comparison matched each proposed rule against the whole current rule list regardless of position, so a pure reorder reported changed=false and the new order was silently dropped.

Compare topology rules positionally so a reorder is reported as a change (update issued), while an unchanged order stays idempotent.

Verified end-to-end on a live NIOS 9.0.6 grid (WAPI 2.12.3): the exact ticket repro reports changed=false on master and changed=true with the fix, and the reordered sequence is reflected on the grid.