### PR TITLE
Fix NPA-1982: nios_dtc_lbdn types/patterns updates silently ignored

### DIFF
--- a/changelogs/fragments/NPA-1982-dtc-lbdn-types-patterns-idempotency.yml
+++ b/changelogs/fragments/NPA-1982-dtc-lbdn-types-patterns-idempotency.yml
@@ -1,0 +1,9 @@
+---
+bugfixes:
+  - nios_dtc_lbdn - updating the ``types`` or ``patterns`` field is no longer
+    silently ignored. These are lists of plain strings, and the idempotency
+    comparison skipped every non-dict list element, so adding, removing or
+    changing a value produced ``changed=false`` and never issued the WAPI
+    update. Scalar lists are now compared by membership so such changes are
+    detected and applied while genuinely unchanged lists stay idempotent
+    (NPA-1982).

--- a/plugins/module_utils/api.py
+++ b/plugins/module_utils/api.py
@@ -1064,7 +1064,13 @@ class WapiModule(WapiBase):
                 return False
 
             elif isinstance(proposed_item, list):
-                if key == 'aliases':
+                # Lists of plain scalars (e.g. the dtc:lbdn 'types' and
+                # 'patterns' fields, or a record's 'aliases') are compared by
+                # membership regardless of order. Without this the generic
+                # subitem loop below skips every non-dict element, so an
+                # added/removed/changed value goes undetected and the module
+                # reports changed=false with no WAPI call made.
+                if key in ('aliases', 'types', 'patterns'):
                     if set(current_item) != set(proposed_item):
                         return False
                 # If the lists are of a different length, the objects cannot be

--- a/tests/unit/plugins/module_utils/test_api.py
+++ b/tests/unit/plugins/module_utils/test_api.py
@@ -864,6 +864,48 @@ class TestNiosApi(unittest.TestCase):
         self.assertFalse(wapi.compare_objects(current, proposed, ib_obj_type=api.NIOS_DTC_LBDN))
 
     # ------------------------------------------------------------------
+    # nios_dtc_lbdn 'types' and 'patterns' are lists of plain strings.
+    # Changing them was silently ignored because the generic list comparison
+    # skips non-dict elements. These are now compared by membership so
+    # additions/removals are detected while reorders stay idempotent.
+    # ------------------------------------------------------------------
+
+    def test_compare_objects_types_addition_returns_false(self):
+        '''Adding a resource-record type must register as a change.'''
+        wapi = api.WapiModule(self.module)
+        proposed = {'types': ['A', 'AAAA']}
+        current = {'types': ['A']}
+        self.assertFalse(wapi.compare_objects(current, proposed, ib_obj_type=api.NIOS_DTC_LBDN))
+
+    def test_compare_objects_types_removal_returns_false(self):
+        '''Removing a resource-record type must register as a change.'''
+        wapi = api.WapiModule(self.module)
+        proposed = {'types': ['A']}
+        current = {'types': ['A', 'AAAA']}
+        self.assertFalse(wapi.compare_objects(current, proposed, ib_obj_type=api.NIOS_DTC_LBDN))
+
+    def test_compare_objects_types_reorder_returns_true(self):
+        '''Reordering identical types must NOT register as a change.'''
+        wapi = api.WapiModule(self.module)
+        proposed = {'types': ['AAAA', 'A']}
+        current = {'types': ['A', 'AAAA']}
+        self.assertTrue(wapi.compare_objects(current, proposed, ib_obj_type=api.NIOS_DTC_LBDN))
+
+    def test_compare_objects_patterns_addition_returns_false(self):
+        '''Adding an LBDN pattern must register as a change.'''
+        wapi = api.WapiModule(self.module)
+        proposed = {'patterns': ['*.a.com', '*.b.com']}
+        current = {'patterns': ['*.a.com']}
+        self.assertFalse(wapi.compare_objects(current, proposed, ib_obj_type=api.NIOS_DTC_LBDN))
+
+    def test_compare_objects_patterns_reorder_returns_true(self):
+        '''Reordering identical patterns must NOT register as a change.'''
+        wapi = api.WapiModule(self.module)
+        proposed = {'patterns': ['*.b.com', '*.a.com']}
+        current = {'patterns': ['*.a.com', '*.b.com']}
+        self.assertTrue(wapi.compare_objects(current, proposed, ib_obj_type=api.NIOS_DTC_LBDN))
+
+    # ------------------------------------------------------------------
     # Issue #59: nsgroup list fields (external_secondaries, external_primaries,
     # grid_primary, grid_secondaries) must detect removal of entries.
     # ------------------------------------------------------------------


### PR DESCRIPTION
The dtc:lbdn 'types' and 'patterns' fields are lists of plain strings. In compare_objects the generic list branch only compares dict elements (via issubset) and skips every non-dict element, and neither key was in any special-case comparison list. As a result any add/remove/change to types or patterns went undetected: the module reported changed=false and never issued the WAPI update.

Compare these scalar lists (alongside the existing 'aliases' handling) by set membership so changes are detected and applied, while reordering an otherwise-identical list stays idempotent.

Reproduced and fix verified against a live NIOS 9.0.6 grid (WAPI 2.13.6): types [A]->[A,AAAA] and patterns additions now report changed=true and persist; reordered re-apply reports changed=false. Added unit tests for add/remove/reorder of both fields.