### PR TITLE
Nios 1980- fix(nios_restartservices): honor check_mode to prevent unintended service restarts

### DIFF
--- a/changelogs/fragments/NIOS-1980-restartservices-honor-check-mode.yml
+++ b/changelogs/fragments/NIOS-1980-restartservices-honor-check-mode.yml
@@ -1,0 +1,9 @@
+---
+bugfixes:
+  - nios_restartservices - honor ``check_mode``. The module declared
+    ``supports_check_mode=True`` but unconditionally called the
+    ``restartservices`` grid function, so a real service restart fired on the
+    grid even when the playbook was run with ``--check``. The module now exits
+    early in check mode without touching the grid and reports a predicted
+    ``changed`` value (``FORCE_RESTART`` -> ``changed=true``,
+    ``RESTART_IF_NEEDED`` -> ``changed=false``).

--- a/plugins/modules/nios_restartservices.py
+++ b/plugins/modules/nios_restartservices.py
@@ -134,8 +134,16 @@ def main():
     grid_obj = wapi.get_object('grid')
     if grid_obj is None:
         module.fail_json(msg='Failed to get NIOS grid information.')
-    result = wapi.call_func('restartservices', grid_obj[0]['_ref'], restart_params)
 
+    if module.check_mode:
+        # Predict the outcome without touching the grid.
+        # FORCE_RESTART always restarts → changed=True.
+        # RESTART_IF_NEEDED only acts when services need it; we cannot
+        # query that state, so report changed=False (conservative).
+        will_change = (restart_params.get('restart_option', 'RESTART_IF_NEEDED') == 'FORCE_RESTART')
+        module.exit_json(changed=will_change)
+
+    result = wapi.call_func('restartservices', grid_obj[0]['_ref'], restart_params)
     module.exit_json(**result)
 
 


### PR DESCRIPTION
## Summary

Fixes a bug in the `nios_restartservices` module where `check_mode` was not honored.
The module declared `supports_check_mode=True` but unconditionally called the
`restartservices` grid function, causing real service restarts on the grid even when
the playbook was run with `--check`.

## Changes

- Added an early exit in `nios_restartservices` when `module.check_mode` is `True`,
  preventing any real interaction with the grid.
- Predicts the expected outcome:
  - `restart_option=FORCE_RESTART` → `changed=True`
  - `restart_option=RESTART_IF_NEEDED` → `changed=False` (conservative, as the
    actual need cannot be queried without touching the grid)
- Added a changelog fragment for the bugfix.
