### PR TITLE
docs: update supported NIOS versions from 8.6.x to 9.0.x and 9.1.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ The `infoblox.nios_modules` collection has the following content:
 
 - Python version 3.10 or later
 - Ansible Core version 2.16 or later
-- NIOS 8.6.x and 9.0.x
+- NIOS 9.0.x and 9.1.x
 - Infoblox WAPI version 2.12.3 or later
 - Python module infoblox-client version 0.6.2
  
@@ -239,8 +239,8 @@ The collection has been tested in the following environments:
     - Ansible Core 2.18
 
 - **NIOS Versions:**
-    - NIOS 8.6.x
     - NIOS 9.0.x
+    - NIOS 9.1.x
 
 ### Known Exceptions and Workarounds
 
@@ -258,7 +258,7 @@ We welcome your contributions to Infoblox Nios Modules. See [CONTRIBUTING.md](ht
 ### Supported Versions
 
 Infoblox NIOS Modules for Ansible Collections supports the following versions:
-- **NIOS Versions:** 8.6.x and 9.0.x
+- **NIOS Versions:** 9.0.x and 9.1.x
 - **Ansible Core Versions:** 2.16 and later
 - **Python Versions:** 3.10 and later
 

--- a/docs/docsite/rst/scenario_guide.rst
+++ b/docs/docsite/rst/scenario_guide.rst
@@ -19,7 +19,7 @@ Before using the collection, ensure your control node meets these requirements:
 
 - Python 3.10 or later
 - Ansible Core 2.16 or later
-- NIOS 8.6.x and 9.0.x
+- NIOS 9.0.x and 9.1.x
 - Infoblox WAPI 2.12.3 or later
 - ``infoblox-client`` 0.6.2
 


### PR DESCRIPTION
Drop end-of-life 8.6.x and add 9.1.x (WAPI 2.14) now supported in collection v1.10.0.