### PR TITLE
Handle exhausted network containers in nios_next_network

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Infoblox NIOS Modules for Ansible Collections enable the management of your NIOS
 ## Description
 Infoblox NIOS Modules for Ansible Collections facilitate the DNS and IPAM automation of 
 VM workloads that are deployed across multiple platforms. The `nios_modules` collection consists of modules and plug-ins required to manage the networks,
-IP addresses, and DNS records in NIOS. The collection is hosted on Ansible Galaxy under `infoblox.nios_modules`.
+IP Addresses, and DNS records in NIOS. The collection is hosted on Ansible Galaxy under `infoblox.nios_modules`.
 
 ### Modules Overview
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Infoblox NIOS Modules for Ansible Collections enable the management of your NIOS
 ## Description
 Infoblox NIOS Modules for Ansible Collections facilitate the DNS and IPAM automation of 
 VM workloads that are deployed across multiple platforms. The `nios_modules` collection consists of modules and plug-ins required to manage the networks,
-IP Addresses, and DNS records in NIOS. The collection is hosted on Ansible Galaxy under `infoblox.nios_modules`.
+IP addresses, and DNS records in NIOS. The collection is hosted on Ansible Galaxy under `infoblox.nios_modules`.
 
 ### Modules Overview
 

--- a/changelogs/fragments/132-nios-next-network-exhausted.yaml
+++ b/changelogs/fragments/132-nios-next-network-exhausted.yaml
@@ -1,0 +1,8 @@
+---
+bugfixes:
+  - nios_next_network - return an empty list instead of raising a fatal
+    ``AnsibleError`` when the requested network-container is exhausted and
+    NIOS reports "Can not find requested number of networks". This allows
+    callers to iterate over a set of supernets without needing
+    ``ignore_errors: true`` workarounds
+    (`#132 <https://github.com/infobloxopen/infoblox-ansible/issues/132>`_).

--- a/plugins/lookup/nios_next_network.py
+++ b/plugins/lookup/nios_next_network.py
@@ -155,4 +155,11 @@ class LookupModule(LookupBase):
             avail_nets = wapi.call_func('next_available_network', ref, {'cidr': cidr, 'num': num, 'exclude': exclude_ip})
             return [avail_nets['networks']]
         except Exception as exc:
+            # When the supernet is exhausted NIOS returns an error containing
+            # "Can not find requested number of networks".  This is a valid,
+            # non-fatal condition (the container is simply full), so return an
+            # empty list instead of raising a fatal AnsibleError.
+            # All other exceptions are still propagated as AnsibleError.
+            if 'can not find requested number of networks' in to_text(exc).lower():
+                return [[]]
             raise AnsibleError(to_text(exc))

--- a/tests/unit/plugins/lookup/test_nios_next_network.py
+++ b/tests/unit/plugins/lookup/test_nios_next_network.py
@@ -135,6 +135,32 @@ class TestNiosNextNetworkLookup(unittest.TestCase):
             self._run(['192.168.10.0/24'], cidr=25, network_view='other')
         self.assertIn('no records found', str(ctx.exception))
 
+    # ---- Issue #132: exhausted supernet should return [] not raise -------
+
+    @patch.object(nios_next_network, 'WapiLookup')
+    def test_exhausted_supernet_returns_empty_list(self, mock_wapi_cls):
+        """NIOS 'Can not find requested number of networks' must return [] not raise."""
+        wapi = MagicMock()
+        wapi.get_object.return_value = [{'_ref': 'ref1', 'network_view': 'default'}]
+        wapi.call_func.side_effect = Exception('Can not find requested number of networks')
+        mock_wapi_cls.return_value = wapi
+
+        result = self._run(['192.168.10.0/24'], cidr=25)
+
+        self.assertEqual(result, [[]])
+
+    @patch.object(nios_next_network, 'WapiLookup')
+    def test_other_wapi_exceptions_still_raise(self, mock_wapi_cls):
+        """Non-exhausted WAPI errors must still surface as AnsibleError."""
+        wapi = MagicMock()
+        wapi.get_object.return_value = [{'_ref': 'ref1', 'network_view': 'default'}]
+        wapi.call_func.side_effect = Exception('Internal server error')
+        mock_wapi_cls.return_value = wapi
+
+        with self.assertRaises(AnsibleError) as ctx:
+            self._run(['192.168.10.0/24'], cidr=25)
+        self.assertIn('Internal server error', str(ctx.exception))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This PR fixes nios_next_network so an exhausted network container is treated as a non-fatal condition.

When NIOS returns Can not find requested number of networks, the lookup now returns an empty list instead of raising AnsibleError. This makes it easier to iterate through multiple supernets without needing ignore_errors: true.