### PR TITLE
Add provider use_paging option for WAPI result-set paging

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Infoblox NIOS Modules for Ansible Collections enable the management of your NIOS
 ## Description
 Infoblox NIOS Modules for Ansible Collections facilitate the DNS and IPAM automation of 
 VM workloads that are deployed across multiple platforms. The `nios_modules` collection consists of modules and plug-ins required to manage the networks,
-IP addresses, and DNS records in NIOS. The collection is hosted on Ansible Galaxy under `infoblox.nios_modules`.
+IP Addresses, and DNS records in NIOS. The collection is hosted on Ansible Galaxy under `infoblox.nios_modules`.
 
 ### Modules Overview
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Infoblox NIOS Modules for Ansible Collections enable the management of your NIOS
 ## Description
 Infoblox NIOS Modules for Ansible Collections facilitate the DNS and IPAM automation of 
 VM workloads that are deployed across multiple platforms. The `nios_modules` collection consists of modules and plug-ins required to manage the networks,
-IP Addresses, and DNS records in NIOS. The collection is hosted on Ansible Galaxy under `infoblox.nios_modules`.
+IP addresses, and DNS records in NIOS. The collection is hosted on Ansible Galaxy under `infoblox.nios_modules`.
 
 ### Modules Overview
 

--- a/changelogs/fragments/293-wapi-paging.yaml
+++ b/changelogs/fragments/293-wapi-paging.yaml
@@ -1,0 +1,9 @@
+---
+minor_changes:
+  - api - Add ``use_paging`` boolean provider option (default ``false``) that
+    enables WAPI result-set paging, preventing silent truncation of large
+    datasets at ``max_results`` (default 1000 per page). When enabled, all
+    matching objects are fetched across as many pages as needed and returned
+    as a single flat list. The value can also be set via the
+    ``INFOBLOX_USE_PAGING`` environment variable
+    (`#293 <https://github.com/infobloxopen/infoblox-ansible/issues/293>`_).

--- a/plugins/doc_fragments/nios.py
+++ b/plugins/doc_fragments/nios.py
@@ -87,10 +87,24 @@ options:
           - Specifies the maximum number of objects to be returned,
             if set to a negative number the appliance will return an error when the
             number of returned objects would exceed the setting.
+          - When C(use_paging) is C(true) this value is used as the page size
+            rather than an absolute cap, so all matching objects are retrieved
+            regardless of how many there are.
           - Value can also be specified using C(INFOBLOX_MAX_RESULTS) environment
             variable.
         type: int
         default: 1000
+      use_paging:
+        description:
+          - When C(true), enables WAPI result-set paging so that arbitrarily
+            large datasets are fetched in multiple page requests rather than
+            being silently truncated at C(max_results).
+          - C(max_results) controls the page size used for each request;
+            the default of 1000 is a safe starting point for most grids.
+          - Value can also be specified using C(INFOBLOX_USE_PAGING) environment
+            variable.
+        type: bool
+        default: false
       http_pool_maxsize:
         description:
           - Insert description here

--- a/plugins/module_utils/api.py
+++ b/plugins/module_utils/api.py
@@ -130,7 +130,8 @@ NIOS_PROVIDER_SPEC = {
     'http_pool_maxsize': dict(type='int', default=10),
     'max_retries': dict(type='int', default=3, fallback=(env_fallback, ['INFOBLOX_MAX_RETRIES'])),
     'wapi_version': dict(default='2.12.3', fallback=(env_fallback, ['INFOBLOX_WAPI_VERSION'])),
-    'max_results': dict(type='int', default=1000, fallback=(env_fallback, ['INFOBLOX_MAX_RESULTS']))
+    'max_results': dict(type='int', default=1000, fallback=(env_fallback, ['INFOBLOX_MAX_RESULTS'])),
+    'use_paging': dict(type='bool', default=False, fallback=(env_fallback, ['INFOBLOX_USE_PAGING']))
 }
 
 
@@ -168,6 +169,11 @@ def get_connector(*args, **kwargs):
     if 'validate_certs' in kwargs.keys():
         kwargs['ssl_verify'] = kwargs['validate_certs']
         kwargs.pop('validate_certs', None)
+
+    # The Connector option is 'paging'; the provider spec uses 'use_paging' to
+    # follow Ansible naming conventions.  Rename before passing to Connector.
+    if 'use_paging' in kwargs:
+        kwargs['paging'] = kwargs.pop('use_paging')
 
     return Connector(kwargs)
 

--- a/tests/unit/plugins/module_utils/test_api.py
+++ b/tests/unit/plugins/module_utils/test_api.py
@@ -36,7 +36,7 @@ class TestNiosApi(unittest.TestCase):
     def test_get_provider_spec(self):
         provider_options = ['host', 'username', 'password', 'cert', 'key', 'validate_certs', 'silent_ssl_warnings',
                             'http_request_timeout', 'http_pool_connections',
-                            'http_pool_maxsize', 'max_retries', 'wapi_version', 'max_results']
+                            'http_pool_maxsize', 'max_retries', 'wapi_version', 'max_results', 'use_paging']
         res = api.WapiBase.provider_spec
         self.assertIsNotNone(res)
         self.assertIn('provider', res)


### PR DESCRIPTION
This PR adds support for WAPI result-set paging through a new provider option, use_paging, so large result sets are no longer silently truncated at max_results.